### PR TITLE
Update modman file to set the filename for the module file.

### DIFF
--- a/modman
+++ b/modman
@@ -1,6 +1,6 @@
 ## Nexcess.net Turpentine (Varnish) Extension
 
-app/etc/modules/Nexcessnet_Turpentine.xml       app/etc/modules/
+app/etc/modules/Nexcessnet_Turpentine.xml       app/etc/modules/Nexcessnet_Turpentine.xml
 app/code/community/Nexcessnet/Turpentine/       app/code/community/Nexcessnet/Turpentine/
 app/design/adminhtml/default/default/layout/turpentine.xml  app/design/adminhtml/default/default/layout/turpentine.xml
 app/design/adminhtml/default/default/template/turpentine/  app/design/adminhtml/default/default/template/turpentine/


### PR DESCRIPTION
I get this error when deploying with modman:
CONFLICT: app/etc/modules/ mapped by app/etc/modules/Nexcessnet_Turpentine.xml already exists and is not a link.
  app/etc/modules/Nexcessnet_Turpentine.xml       app/etc/modules/

This fixes it.
