### PR TITLE
Fixes a bug with using a variable which doesn't exist.

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Observer/Esi.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Observer/Esi.php
@@ -149,7 +149,7 @@ class Nexcessnet_Turpentine_Model_Observer_Esi extends Varien_Event_Observer {
                 return;
             } elseif( $esiHelper->getEsiBlockLogEnabled() ) {
                 $debugHelper->logInfo( 'Block check passed, injecting block: %s',
-                    $block->getNameInLayout() );
+                    $blockObject->getNameInLayout() );
             }
             $ttlParam = $esiHelper->getEsiTtlParam();
             $cacheTypeParam = $esiHelper->getEsiCacheTypeParam();


### PR DESCRIPTION
I kept getting this error:

2013-03-05T10:54:18+00:00 ERR (3): Notice: Undefined variable: block  in /var/www/shop/extensions/magento-turpentine-0.5.0/app/code/community/Nexcessnet/Turpentine/Model/Observer/Esi.php on line 152

So i've changed the usage of $block to $blockObject like in the other log calls.
