### PR TITLE
Strip google-relate query parameters

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/misc/version-2.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-2.vcl
@@ -203,6 +203,14 @@ sub vcl_recv {
                 req.url ~ "(?:[?&](?:{{get_param_excludes}})(?=[&=]|$))") {
             return (pass);
         }
+		
+		if(req.url ~ "(\?|&)(utm_source|utm_medium|utm_campaign|gclid|cx|ie|cof|siteurl)=") {
+			# Strip out Google related parameters
+			set req.url=regsuball(req.url,"&(utm_source|utm_medium|utm_campaign|gclid|cx|ie|cof|siteurl)=([A-z0-9_\-\.%25]+)","");
+			set req.url=regsuball(req.url,"\?(utm_source|utm_medium|utm_campaign|gclid|cx|ie|cof|siteurl)=([A-z0-9_\-\.%25]+)","?");
+			set req.url=regsub(req.url,"\?&","?");
+			set req.url=regsub(req.url,"\?$","");
+		}		
         return (lookup);
     }
     # else it's not part of magento so do default handling (doesn't help

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
@@ -202,6 +202,14 @@ sub vcl_recv {
             # TODO: should this be pass or pipe?
             return (pass);
         }
+		
+		if(req.url ~ "(\?|&)(utm_source|utm_medium|utm_campaign|gclid|cx|ie|cof|siteurl)=") {
+			# Strip out Google related parameters
+			set req.url=regsuball(req.url,"&(utm_source|utm_medium|utm_campaign|gclid|cx|ie|cof|siteurl)=([A-z0-9_\-\.%25]+)","");
+			set req.url=regsuball(req.url,"\?(utm_source|utm_medium|utm_campaign|gclid|cx|ie|cof|siteurl)=([A-z0-9_\-\.%25]+)","?");
+			set req.url=regsub(req.url,"\?&","?");
+			set req.url=regsub(req.url,"\?$","");
+		}		
         # everything else checks out, try and pull from the cache
         return (lookup);
     }


### PR DESCRIPTION
Hi.

I have found that varnish with turpentine doesn't send a cached page version if one of Google-related parameters exist. Here is a patch that could solve this and increase hitrate. Taken from http://blog.rac.me.uk/2010/03/03/normalizing_the_url_in_varnish/
However I'm a varnish noob, something could be wrong.

Thanks.
