### PR TITLE
Added filters to prevent flush/ban matching all URLs like (?:myproduct|) and (?:)

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Helper/Ban.php
+++ b/app/code/community/Nexcessnet/Turpentine/Helper/Ban.php
@@ -30,9 +30,16 @@ class Nexcessnet_Turpentine_Helper_Ban extends Mage_Core_Helper_Abstract {
     public function getProductBanRegex( $product ) {
         $urlPatterns = array();
         foreach( $this->getParentProducts( $product ) as $parentProduct ) {
-            $urlPatterns[] = $parentProduct->getUrlKey();
+            if ( $parentProduct->getUrlKey() ) {
+                $urlPatterns[] = $parentProduct->getUrlKey();
+            }
         }
-        $urlPatterns[] = $product->getUrlKey();
+        if ( $product->getUrlKey() ) {
+            $urlPatterns[] = $product->getUrlKey();
+        }
+        if ( empty($urlPatterns) ) {
+            $urlPatterns[] = "##_NEVER_MATCH_##";
+        }
         $pattern = sprintf( '(?:%s)', implode( '|', $urlPatterns ) );
         return $pattern;
     }

--- a/app/code/community/Nexcessnet/Turpentine/Model/Observer/Ban.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Observer/Ban.php
@@ -280,12 +280,17 @@ class Nexcessnet_Turpentine_Model_Observer_Ban extends Varien_Event_Observer {
             implode( '|', array_unique( $productIds ) ) );
         $patterns[] = sprintf( '/review/product/view/id/%d/',
             $review->getEntityId() );
-        $patterns[] = sprintf( '(?:%s)', implode( '|',
-            array_unique( array_map(
-                create_function( '$p',
-                    'return $p->getUrlModel()->formatUrlKey( $p->getName() );' ),
-                $products ) )
-        ) );
+        $productPatterns = array();
+        foreach ( $products as $p ) {
+            $urlKey = $p->getUrlModel()->formatUrlKey( $p->getName() );
+            if ( $urlKey ) {
+                $productPatterns[] = $urlKey;
+            }
+        }
+        if ( !empty($productPatterns) ) {
+            $productPatterns = array_unique( $productPatterns );
+            $patterns[] = sprintf( '(?:%s)', implode( '|', $productPatterns ) );
+        }
         $urlPattern = implode( '|', $patterns );
 
         $result = $this->_getVarnishAdmin()->flushUrl( $urlPattern );


### PR DESCRIPTION
Hi Turpentine Team,

On our site we had the problem that the whole Varnish cache got flushed upon the save of some single products.
The problem turned out to be that sometimes the URL for a product is empty in our Magento, because the products come from an import.

That is why I created a fix to solve this.
I added filters to prevent flush/ban matching all URLs like (?:myproduct|) and (?:) which cause the whole cache to be flushed. Notice the pipe sign before the closing parenthesis of the first example.

Please merge my changes into the core development branch of the plugin.

Kind regards,
Jeroen Vermeulen.
