### PR TITLE
Fix for ESI blocks not rendering child blocks

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Helper/Data.php
+++ b/app/code/community/Nexcessnet/Turpentine/Helper/Data.php
@@ -292,6 +292,14 @@ class Nexcessnet_Turpentine_Helper_Data extends Mage_Core_Helper_Abstract {
             foreach( $blockNode->xpath( './block | ./reference' ) as $childBlockNode ) {
                 $blockNames = array_merge( $blockNames,
                     $this->_getChildBlockNames( $childBlockNode ) );
+                if ( $this->getLayout() instanceof Varien_Simplexml_Config ) {
+                    foreach ( $this->getLayout()->getNode()->xpath( sprintf(
+                        '//reference[@name=\'%s\']', (string)$childBlockNode['name'] ) ) as $childBlockLayoutNode ) {
+                        $blockNames = array_merge( $blockNames,
+                            $this->_getChildBlockNames( $childBlockLayoutNode ) );
+
+                    }
+                }
             }
         } else {
             $blockNames = array();

--- a/app/code/community/Nexcessnet/Turpentine/controllers/EsiController.php
+++ b/app/code/community/Nexcessnet/Turpentine/controllers/EsiController.php
@@ -156,6 +156,7 @@ class Nexcessnet_Turpentine_EsiController extends Mage_Core_Controller_Front_Act
             $esiData->getNameInLayout() ) ) );
         if( $blockNode instanceof Varien_Simplexml_Element ) {
             $nodesToGenerate = Mage::helper( 'turpentine/data' )
+                ->setLayout( $layout )
                 ->getChildBlockNames( $blockNode );
             Mage::getModel( 'turpentine/shim_mage_core_layout' )
                 ->shim_generateFullBlock( $blockNode );


### PR DESCRIPTION
When ESI blocks are generated the scope of layout is limited only to ESI block definition. For example if layout XML looks like:

``` xml
<reference name="header">
    <block name="some_block" (...)></block>
</reference>
<reference name="some_block">
    <block name="child_block" (...)></block>
</reference>
```

the "child_block" won't be rendered. 

The fix will search for references to blocks defined withing ESI block across entire layout definition.

```
modified:   app/code/community/Nexcessnet/Turpentine/Helper/Data.php
modified:   app/code/community/Nexcessnet/Turpentine/controllers/EsiController.php
```
