### PR TITLE
Fix ESI detection for message block

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Block/Core/Messages.php
+++ b/app/code/community/Nexcessnet/Turpentine/Block/Core/Messages.php
@@ -353,7 +353,7 @@ class Nexcessnet_Turpentine_Block_Core_Messages extends Mage_Core_Block_Messages
      * @return boolean
      */
     protected function _isEsiRequest() {
-        return is_subclass_of( Mage::app()->getRequest(),
+        return is_a( Mage::app()->getRequest(),
             'Nexcessnet_Turpentine_Model_Dummy_Request' );
     }
 }


### PR DESCRIPTION
The message block will never correctly detect the Request to be an ESI request, since is_subclass_of() does not include the _actual_ class name, but only the parent classes. is_a() should be used instead.
