### PR TITLE
Feature: Logging of Varnish flushes

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Helper/Debug.php
+++ b/app/code/community/Nexcessnet/Turpentine/Helper/Debug.php
@@ -50,6 +50,13 @@ class Nexcessnet_Turpentine_Helper_Debug extends Mage_Core_Helper_Abstract {
                     } else {
                         return;
                     }
+                case 'Flush':
+                    if( Mage::helper( 'turpentine/varnish' )
+                            ->getFlushDebugEnabled() ) {
+                        return $this->_log( Zend_Log::INFO, $message );
+                    } else {
+                        return;
+                    }
                 default:
                     break;
             }

--- a/app/code/community/Nexcessnet/Turpentine/Helper/Varnish.php
+++ b/app/code/community/Nexcessnet/Turpentine/Helper/Varnish.php
@@ -43,6 +43,16 @@ class Nexcessnet_Turpentine_Helper_Varnish extends Mage_Core_Helper_Abstract {
     }
 
     /**
+     * Get whether flush logging is enabled or not
+     *
+     * @return bool
+     */
+    public function getFlushDebugEnabled() {
+        return (bool)Mage::getStoreConfig(
+            'turpentine_varnish/general/flush_debug' );
+    }
+
+    /**
      * Check if the request passed through Varnish (has the correct secret
      * handshake header)
      *

--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Admin.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Admin.php
@@ -40,6 +40,7 @@ class Nexcessnet_Turpentine_Model_Varnish_Admin {
      */
     public function flushUrl( $subPattern ) {
         $result = array();
+        Mage::helper( 'turpentine/debug' )->logFlush( 'flush URL: %s', $subPattern );
         foreach( Mage::helper( 'turpentine/varnish' )->getSockets() as $socket ) {
             $socketName = $socket->getConnectionString();
             try {
@@ -62,6 +63,7 @@ class Nexcessnet_Turpentine_Model_Varnish_Admin {
     public function flushExpression() {
         $args = func_get_args();
         $result = array();
+        Mage::helper( 'turpentine/debug' )->logFlush( 'flush expression: %s', implode(' ',$args) );
         foreach( Mage::helper( 'turpentine/varnish' )->getSockets() as $socket ) {
             $socketName = $socket->getConnectionString();
             try {

--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Admin/Socket.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Admin/Socket.php
@@ -444,6 +444,9 @@ class Nexcessnet_Turpentine_Model_Varnish_Admin_Socket {
         $data = implode( ' ', array_merge(
             array( sprintf( '"%s"', $verb ) ),
             $cleanedParams ) );
+        if ( 'ban' === substr( $verb, 0, 3 ) || 'purge' === substr( $verb, 0, 5 ) ) {
+            Mage::helper( 'turpentine/debug' )->logFlush( 'sending socket %s:%s flush command: %s', $this->_host, $this->_port, $data );
+        }
         $response = $this->_write( $data )->_read();
         if( $response['code'] !== $okCode && !is_null( $okCode ) ) {
             Mage::helper( 'turpentine/debug' )->logDebug(

--- a/app/code/community/Nexcessnet/Turpentine/etc/config.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/config.xml
@@ -29,6 +29,7 @@
                 <auto_apply_on_save>1</auto_apply_on_save>
                 <varnish_debug>0</varnish_debug>
                 <block_debug>0</block_debug>
+                <flush_debug>0</flush_debug>
                 <ajax_messages>1</ajax_messages>
                 <fix_product_toolbar>0</fix_product_toolbar>
                 <crawler_enable>0</crawler_enable>

--- a/app/code/community/Nexcessnet/Turpentine/etc/system.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/system.xml
@@ -72,6 +72,16 @@
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
                         </block_debug>
+                        <flush_debug translate="label comment" module="turpentine">
+                            <label>Enable Flush Logging</label>
+                            <comment>Log Varnish cache flushes</comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>turpentine/config_select_toggle</source_model>
+                            <sort_order>55</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </flush_debug>
                         <ajax_messages translate="label" module="turpentine">
                             <label>Enable AJAX Flash Messages</label>
                             <comment>Enable fixing the messages block to load via AJAX, disable if you already have an extension that does this</comment>


### PR DESCRIPTION
Hi Turpentine Team,

On several of my client's installations they asked me questions about why sometimes pages were not served from Varnish cache. Most of the time this was caused by flushes. Some needed and some not on purpose.
To get an easier grip on this I added the feature to log flushes, with the option to enable it from the Magento configuration (disabled by default).

Please merge my changes into the core devel branch.

Kind regards,
Jeroen Vermeulen.
