### PR TITLE
Fix for /js/ and /css/ URLs not being cached when ‘Add Store Code to Urls’ is enabled for all store views

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
@@ -123,7 +123,7 @@ sub vcl_recv {
     {{normalize_host}}
 
     # check if the request is for part of magento
-    if (req.url ~ "{{url_base_regex}}") {
+    if (req.url ~ "{{url_base_regex}}" || req.url ~ "^/(skin|js)/") {
         # set this so Turpentine can see the request passed through Varnish
         set req.http.X-Turpentine-Secret-Handshake = "{{secret_handshake}}";
         # use the special admin backend and pipe if it's for the admin section


### PR DESCRIPTION
Bugfix for: 
The "check if the request is for part of magento" regex does not match for URLs starting with "/skin/" and "/js/" when a shop has enabled ‘Add Store Code to Urls’ for all store views. 
This causes caching not to work for JS and CSS URLs when a cookie is set.

Please merge my small change to the "devel" branch.
