### PR TITLE
Fix verification of the bypass cookie value

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Helper/Varnish.php
+++ b/app/code/community/Nexcessnet/Turpentine/Helper/Varnish.php
@@ -162,9 +162,10 @@ class Nexcessnet_Turpentine_Helper_Varnish extends Mage_Core_Helper_Abstract {
      * @return boolean
      */
     public function isBypassEnabled() {
-        $bypassEnabled = (bool)Mage::getModel( 'core/cookie' )->get(
-                Mage::helper( 'turpentine/data' )->getBypassCookieName() ) ===
-            $this->getSecretHandshake();
+        $cookieName = Mage::helper( 'turpentine/data' )->getBypassCookieName();
+        $cookieValue = Mage::getModel( 'core/cookie' )->get( $cookieName );
+
+        $bypassEnabled = (bool)$cookieValue === (bool)$this->getSecretHandshake();
 
         return $bypassEnabled;
     }


### PR DESCRIPTION
Hi,

I have just noticed a small regression since the last upgrade.
It's related to the functionality that allows us to bypass Varnish with a cookie.

This feature still works fine...
...until you want to delete the cookie. ^^

Indeed, the verification done with **Nexcessnet_Turpentine_Helper_Varnish:: isBypassEnabled()** is broken.
You try to use a type comparison with a boolean (the cookie value) and a string (the secret handshake). The result is inevitably always false and it's impossible to remove the cookie from the back-office.

I hope this will help.

Kind regards,
Alexandre Jardin
