### PR TITLE
Implemented ban lurker friendly bans

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Admin.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Admin.php
@@ -43,7 +43,9 @@ class Nexcessnet_Turpentine_Model_Varnish_Admin {
         foreach( Mage::helper( 'turpentine/varnish' )->getSockets() as $socket ) {
             $socketName = $socket->getConnectionString();
             try {
-                $socket->ban_url( $subPattern );
+                // We don't use "ban_url" here, because we want to do lurker friendly bans.
+                // Lurker friendly bans get cleaned up, so they don't slow down Varnish.
+                $socket->ban( 'obj.http.X-Varnish-URL', '~', $subPattern );
             } catch( Mage_Core_Exception $e ) {
                 $result[$socketName] = $e->getMessage();
                 continue;

--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Admin/Socket.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Admin/Socket.php
@@ -57,6 +57,8 @@
  * @method array vcl_show()
  * @method array param_show()
  * @method array param_set()
+ * Warning: ban_url does a non-lurker-friendly ban. This means it is not cleaned
+ *          up from the ban list. A long ban list will slow down Varnish.
  * @method array ban_url()
  * @method array ban()
  * @method array ban_list()

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-2.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-2.vcl
@@ -258,6 +258,10 @@ sub vcl_fetch {
     # set the grace period
     set req.grace = {{grace_period}}s;
 
+    # Store the URL in the response object, we need this to do lurker friendly bans later
+    set beresp.http.X-Varnish-Host = req.http.host;
+    set beresp.http.X-Varnish-URL = req.url;
+
     # if it's part of magento...
     if (req.url ~ "{{url_base_regex}}") {
         # we handle the Vary stuff ourselves for now, we'll want to actually
@@ -365,6 +369,8 @@ sub vcl_deliver {
         remove resp.http.X-Turpentine-Flush-Events;
         remove resp.http.X-Turpentine-Block;
         remove resp.http.X-Varnish-Session;
+        remove resp.http.X-Varnish-Host;
+        remove resp.http.X-Varnish-URL;
         # this header indicates the session that originally generated a cached
         # page. it *must* not be sent to a client in production with lax
         # session validation or that session can be hijacked

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
@@ -256,6 +256,10 @@ sub vcl_fetch {
     # set the grace period
     set req.grace = {{grace_period}}s;
 
+    # Store the URL in the response object, to be able to do lurker friendly bans later
+    set beresp.http.X-Varnish-Host = req.http.host;
+    set beresp.http.X-Varnish-URL = req.url;
+
     # if it's part of magento...
     if (req.url ~ "{{url_base_regex}}") {
         # we handle the Vary stuff ourselves for now, we'll want to actually
@@ -363,6 +367,8 @@ sub vcl_deliver {
         unset resp.http.X-Turpentine-Flush-Events;
         unset resp.http.X-Turpentine-Block;
         unset resp.http.X-Varnish-Session;
+        unset resp.http.X-Varnish-Host;
+        unset resp.http.X-Varnish-URL;
         # this header indicates the session that originally generated a cached
         # page. it *must* not be sent to a client in production with lax
         # session validation or that session can be hijacked


### PR DESCRIPTION
This change will prevent the ban list from growing big and slowing down Varnish.
Info about lurker-friendly bans: https://www.varnish-cache.org/docs/3.0/tutorial/purging.html#bans

I tested this improvement on a very big shop and and several average sized shops.
After this change the ban list (total active bans) is kept clean on the average shops. On the big shop the ban list is a lot smaller than before. This means performance improvement, because each hit is checked against the whole ban list.

Make sure the ban-lurker is enabled by setting the `ban_lurker_sleep` to non-zero.
Default it is set to 0.01 since Varnish 3.0. You can check with: `varnishadm 'param.show ban_lurker_sleep'`
To get rid of old non-lurker-friendly bans after installing this update, you need to restart Varnish.

Kind regards,
Jeroen Vermeulen - Freelance Mageno, PHP & Hosting expert - info@jeroenvermeulen.eu
