### PR TITLE
Fix for caching static URLs - v2

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
@@ -211,19 +211,21 @@ abstract class Nexcessnet_Turpentine_Model_Varnish_Configurator_Abstract {
     }
 
     /**
-     * Get the path part of each store's base URL
+     * Get the path part of each store's base URL and static file URLs
      *
      * @return array
      */
     protected function _getBaseUrlPaths() {
         $paths = array();
-        foreach( Mage::app()->getStores() as $storeId => $store ) {
-            $paths[] = parse_url( $store->getBaseUrl(
-                    Mage_Core_Model_Store::URL_TYPE_LINK, false ),
-                PHP_URL_PATH );
-            $paths[] = parse_url( $store->getBaseUrl(
-                    Mage_Core_Model_Store::URL_TYPE_LINK, true ),
-                PHP_URL_PATH );
+        foreach( Mage::app()->getStores() as $store ) {
+            $linkTypes = array( Mage_Core_Model_Store::URL_TYPE_LINK,
+                                Mage_Core_Model_Store::URL_TYPE_JS,
+                                Mage_Core_Model_Store::URL_TYPE_SKIN,
+                                Mage_Core_Model_Store::URL_TYPE_MEDIA );
+            foreach ( $linkTypes as $linkType ) {
+                $paths[] = parse_url( $store->getBaseUrl( $linkType , false ), PHP_URL_PATH );
+                $paths[] = parse_url( $store->getBaseUrl( $linkType , true ), PHP_URL_PATH );
+            }
         }
         $paths = array_unique( $paths );
         usort( $paths, create_function( '$a, $b',


### PR DESCRIPTION
Bugfix for: The "check if the request is for part of magento" regex does not match for URLs starting with `/js/`, `/skin/` and `/media/` when a shop has enabled _Add Store Code to Urls_ for all stores. This causes caching not to work for these URLs when a cookie is set.
This fix is the improved version of https://github.com/nexcess/magento-turpentine/pull/399 after the discussion there with @aheadley
