### PR TITLE
Fix for Mageworx_xsitemap incompatibility

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Helper/Cron.php
+++ b/app/code/community/Nexcessnet/Turpentine/Helper/Cron.php
@@ -171,7 +171,7 @@ class Nexcessnet_Turpentine_Helper_Cron extends Mage_Core_Helper_Abstract {
                     $urls[] = $prod->getProductUrl();
                 }
             }
-            $sitemap = (Mage::getConfig()->getNode('modules/Mageworx_XSitemap') !== FALSE) ?
+            $sitemap = (Mage::getConfig()->getNode('modules/MageWorx_XSitemap') !== FALSE) ?
                                                            'xsitemap/cms_page' : 'sitemap/cms_page';
             foreach( Mage::getResourceModel( $sitemap )
                         ->getCollection( $storeId ) as $item ) {


### PR DESCRIPTION
When installing Turpentine on a Magento installation that uses mageworx_xsitemap, the usage of 'sitemap/cms_page' on line 175 on Mage::getResourceModel() of Helper/cron.php is fundamentally broken due to a rewrite, which dumps a fatal error on this line.

This can be reproduced by installing the mageworx_xsitemap module (our version came bundled with the Mageworx_Seosuite), navigating to the cache management page in the admin panel, and clicking Flush Magento Cache.

A fix for this issue would be to check if the module exists and if so, alter the supplied argument in Mage::getResourceModel();

```
public function getAllUrls() {
    $urls = array();
    $origStore = Mage::app()->getStore();
    $visibility = array(
        Mage_Catalog_Model_Product_Visibility::VISIBILITY_BOTH,
        Mage_Catalog_Model_Product_Visibility::VISIBILITY_IN_CATALOG,
    );
    foreach( Mage::app()->getStores() as $storeId => $store ) {
        Mage::app()->setCurrentStore( $store );
        $baseUrl = $store->getBaseUrl( Mage_Core_Model_Store::URL_TYPE_LINK );
        $urls[] = $baseUrl;
        foreach( Mage::getModel( 'catalog/category' )
                    ->getCollection( $storeId ) as $cat ) {
            $urls[] = $cat->getUrl();
            foreach( $cat->getProductCollection( $storeId )
                        ->addUrlRewrite( $cat->getId() )
                        ->addAttributeToFilter( 'visibility', $visibility )
                            as $prod ) {
                $urls[] = $prod->getProductUrl();
            }
        }
        $sitemap = (Mage::getConfig()->getNode('modules/MageWorx_XSitemap') !== FALSE) ?
                                                        'xsitemap/cms_page' : 'sitemap/cms_page';
        foreach( Mage::getResourceModel( $sitemap )
                    ->getCollection( $storeId ) as $item ) {
            $urls[] = $baseUrl . $item->getUrl();
        }
    }
    Mage::app()->setCurrentStore( $origStore );
    return array_unique( $urls );
}
```

The above change successfully resolves the fatal error that is dumped upon clicking the cache clear button (after checking the debug log output I can confirm this generates the correct URL's).

Would love to see this merged so I don't have to do this every-time there is an upgrade for Turpentine!

I do apologise if I got something wrong with this pull request, first time doing one!
