### PR TITLE
Added <only_cache_if> ESI param, now we can cache the messages blocks

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/controllers/EsiController.php
+++ b/app/code/community/Nexcessnet/Turpentine/controllers/EsiController.php
@@ -100,10 +100,23 @@ class Nexcessnet_Turpentine_EsiController extends Mage_Core_Controller_Front_Act
                 $appShim->shim_setRequest( $dummyRequest );
                 $block = $this->_getEsiBlock( $esiData );
                 if( $block ) {
+                    $blockEsiOptions = $block->getEsiOptions();
                     $block->setEsiOptions( false );
                     $resp->setBody( $block->toHtml() );
                     if( (int)$req->getParam( $esiHelper->getEsiTtlParam() ) > 0 ) {
                         $cacheFlag = true;
+                        if ( isset( $blockEsiOptions['only_cache_if'] ) ) {
+                            switch ( $blockEsiOptions['only_cache_if'] ) {
+                                case 'empty':
+                                    $cacheFlag = ( '' === $resp->getBody() );
+                                    break;
+                                case 'no_text':
+                                    $cacheFlag = ( '' === trim( strip_tags( $resp->getBody() ) ) );
+                                    break;
+                                default:
+                                    $cacheFlag = false;
+                            }
+                        }
                     }
                     if( $esiData->getEsiMethod() == 'ajax' ) {
                         $resp->setHeader( 'Access-Control-Allow-Origin',

--- a/app/design/frontend/base/default/layout/turpentine_esi.xml
+++ b/app/design/frontend/base/default/layout/turpentine_esi.xml
@@ -102,19 +102,14 @@
                 </params>
             </action>
         </reference>
-
-        <!-- Messages are not cached because the "messages cleared" event is
-        not reliable -->
         <reference name="global_messages">
             <action method="setEsiOptions">
                 <params>
                     <access>private</access>
-                    <method>ajax</method>
-                    <!-- if this is ever cached we should flush on this event
                     <flush_events>
                         <core_session_abstract_add_message/>
                     </flush_events>
-                    -->
+                    <only_cache_if>no_text</only_cache_if>
                 </params>
             </action>
         </reference>
@@ -122,12 +117,10 @@
             <action method="setEsiOptions">
                 <params>
                     <access>private</access>
-                    <method>ajax</method>
-                    <!-- if this is ever cached we should flush on this event
                     <flush_events>
                         <core_session_abstract_add_message/>
                     </flush_events>
-                    -->
+                    <only_cache_if>no_text</only_cache_if>
                 </params>
             </action>
         </reference>


### PR DESCRIPTION
Previously the messages ESI blocks were not cached because the "messages cleared" event is not reliable.

My solution is to cache the messages block only when it does not contain a message (`no_text`).
When a message needs to be communicated to the visitor the `core_session_abstract_add_message` event flushes the block. The block containing the message will not be cached because it does not get passed the `no_text` filter. During the next page visit an ESI request is passed to Magento, which serves an empty messages block, which can be cached again.

Being able to cache the `global_messages` and the `messages` blocks is a huge improvement, it highly reduces the number of hits on the Magento backend.

I have implemented `<only_cache_if>no_text</only_cache_if>` and `<only_cache_if>empty</only_cache_if>`.
