### PR TITLE
Add config option to control stripping of whitespaces from generated VCL files

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Helper/Data.php
+++ b/app/code/community/Nexcessnet/Turpentine/Helper/Data.php
@@ -270,6 +270,32 @@ class Nexcessnet_Turpentine_Helper_Data extends Mage_Core_Helper_Abstract {
             'turpentine_varnish/general/auto_apply_on_save' );
     }
 
+	/**
+	 * Get config value specifying when to strip VCL whitespaces
+	 *
+	 * @return string
+	 */
+	public function getStripVclWhitespace() {
+		return Mage::getStoreConfig(
+			'turpentine_varnish/general/strip_vcl_whitespace' );
+	}
+
+	/**
+	 * Check if VCL whitespaces should be stripped for the given action
+	 *
+	 * @param string $action can be either "apply", "save" or "download"
+	 * @return bool
+	 */
+	public function shouldStripVclWhitespace($action) {
+		$configValue = $this->getStripVclWhitespace();
+		if ( $configValue==='always' ) {
+			return true;
+		} elseif ( $configValue==='apply' && $action==='apply' ) {
+			return true;
+		}
+		return false;
+	}
+
     /**
      * Get the cookie name for the Varnish bypass
      *

--- a/app/code/community/Nexcessnet/Turpentine/Model/Config/Select/StripWhitespace.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Config/Select/StripWhitespace.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Nexcess.net Turpentine Extension for Magento
+ * Copyright (C) 2012  Nexcess.net L.L.C.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+class Nexcessnet_Turpentine_Model_Config_Select_stripWhitespace {
+    public function toOptionArray() {
+        $helper = Mage::helper('turpentine');
+        return array(
+            array( 'value' => 'always', 'label' => $helper->__( 'Always' ) ),
+            array( 'value' => 'apply', 'label' => $helper->__( 'Only when applying directly to Varnish' ) ),
+            array( 'value' => 'never', 'label' => $helper->__( 'Never' ) ),
+        );
+    }
+}

--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Admin.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Admin.php
@@ -99,13 +99,14 @@ class Nexcessnet_Turpentine_Model_Varnish_Admin {
      */
     public function applyConfig() {
         $result = array();
+	    $helper = Mage::helper( 'turpentine' );
         foreach( Mage::helper( 'turpentine/varnish' )->getSockets() as $socket ) {
             $cfgr = Nexcessnet_Turpentine_Model_Varnish_Configurator_Abstract::getFromSocket( $socket );
             $socketName = $socket->getConnectionString();
             if( is_null( $cfgr ) ) {
                 $result[$socketName] = 'Failed to load configurator';
             } else {
-                $vcl = $cfgr->generate();
+                $vcl = $cfgr->generate( $helper->shouldStripVclWhitespace('apply') );
                 $vclName = Mage::helper( 'turpentine/data' )
                     ->secureHash( microtime() );
                 try {

--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
@@ -71,7 +71,7 @@ abstract class Nexcessnet_Turpentine_Model_Varnish_Configurator_Abstract {
         $this->_options = array_merge( $this->_options, $options );
     }
 
-    abstract public function generate();
+    abstract public function generate($doClean=true);
     // abstract protected function _getTemplateVars();
 
     /**

--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Version2.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Version2.php
@@ -27,13 +27,14 @@ class Nexcessnet_Turpentine_Model_Varnish_Configurator_Version2
     /**
      * Generate the Varnish 2.1-compatible VCL
      *
+     * @param bool $doClean if true, VCL will be cleaned (whitespaces stripped, etc.)
      * @return string
      */
-    public function generate() {
+    public function generate($doClean=true) {
         $tplFile = $this->_getVclTemplateFilename( self::VCL_TEMPLATE_FILE );
         $vcl = $this->_formatTemplate( file_get_contents( $tplFile ),
             $this->_getTemplateVars() );
-        return $this->_cleanVcl( $vcl );
+	    return $doClean ? $this->_cleanVcl( $vcl ) : $vcl;
     }
 
     protected function _getAdvancedSessionValidation() {

--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Version3.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Version3.php
@@ -27,13 +27,14 @@ class Nexcessnet_Turpentine_Model_Varnish_Configurator_Version3
     /**
      * Generate the Varnish 3.0-compatible VCL
      *
+     * @param bool $doClean if true, VCL will be cleaned (whitespaces stripped, etc.)
      * @return string
      */
-    public function generate() {
+    public function generate($doClean=true) {
         $tplFile = $this->_getVclTemplateFilename( self::VCL_TEMPLATE_FILE );
         $vcl = $this->_formatTemplate( file_get_contents( $tplFile ),
             $this->_getTemplateVars() );
-        return $this->_cleanVcl( $vcl );
+        return $doClean ? $this->_cleanVcl( $vcl ) : $vcl;
     }
 
     protected function _getAdvancedSessionValidation() {

--- a/app/code/community/Nexcessnet/Turpentine/controllers/Varnish/ManagementController.php
+++ b/app/code/community/Nexcessnet/Turpentine/controllers/Varnish/ManagementController.php
@@ -157,7 +157,8 @@ class Nexcessnet_Turpentine_Varnish_ManagementController
         } else {
             Mage::dispatchEvent( 'turpentine_varnish_save_config',
                 array( 'cfgr' => $cfgr ) );
-            $result = $cfgr->save( $cfgr->generate() );
+            $result = $cfgr->save( $cfgr->generate(
+	            Mage::helper('turpentine')->shouldStripVclWhitespace('save') ) );
             if( $result[0] ) {
                 $this->_getSession()
                     ->addSuccess( Mage::helper('turpentine')
@@ -183,7 +184,8 @@ class Nexcessnet_Turpentine_Varnish_ManagementController
             $this->_getSession()->addError( $this->__( 'Failed to load configurator' ) );
             $this->_redirect( '*/cache' );
         } else {
-            $vcl = $cfgr->generate();
+            $vcl = $cfgr->generate(
+	            Mage::helper( 'turpentine' )->shouldStripVclWhitespace('download') );
             $this->getResponse()
                 ->setHttpResponseCode( 200 )
                 ->setHeader( 'Content-Type', 'text/plain', true )

--- a/app/code/community/Nexcessnet/Turpentine/etc/config.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/config.xml
@@ -27,6 +27,7 @@
         <turpentine_varnish>
             <general>
                 <auto_apply_on_save>1</auto_apply_on_save>
+                <strip_vcl_whitespace>always</strip_vcl_whitespace>
                 <varnish_debug>0</varnish_debug>
                 <block_debug>0</block_debug>
                 <ajax_messages>1</ajax_messages>

--- a/app/code/community/Nexcessnet/Turpentine/etc/system.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/system.xml
@@ -52,6 +52,16 @@
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
                         </auto_apply_on_save>
+                        <strip_vcl_whitespace translate="label,comment" module="turpentine">
+                            <label>Strip whitespace from VCL files</label>
+                            <comment>If whitespace stripping is disabled, generated VCL files will get larger and may exceed the cli_buffer varnish config.</comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>turpentine/config_select_stripWhitespace</source_model>
+                            <sort_order>25</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </strip_vcl_whitespace>
                         <varnish_debug translate="label" module="turpentine">
                             <label>Enable Debug Info</label>
                             <comment>It is a major security vulnerability, to leave this enabled on production sites</comment>


### PR DESCRIPTION
As suggested in https://github.com/nexcess/magento-turpentine/issues/483 implement a config option in the generic Turpentine settings to enable or disable stripping of whitespaces when generating VCLs.
