### PR TITLE
Force unsecure esi url

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Helper/Esi.php
+++ b/app/code/community/Nexcessnet/Turpentine/Helper/Esi.php
@@ -357,7 +357,7 @@ class Nexcessnet_Turpentine_Helper_Esi extends Mage_Core_Helper_Abstract {
             $this->getEsiScopeParam()       => 'global',
             $this->getEsiCacheTypeParam()   => 'private',
         );
-        return Mage::getUrl( 'turpentine/esi/getFormKey', $urlOptions );
+        return $this->unsecureUrl(Mage::getUrl( 'turpentine/esi/getFormKey', $urlOptions ));
     }
 
     /**
@@ -400,4 +400,16 @@ class Nexcessnet_Turpentine_Helper_Esi extends Mage_Core_Helper_Abstract {
         Varien_Profiler::stop( 'turpentine::helper::esi::_loadLayoutXml' );
         return $layoutXml;
     }
+
+	/**
+	 * Replace https scheme in ESI URLs with http to prevent secure ESI calls
+	 * Varnish does support HTTPS ESI urls, but only properly as of 3.0.5 because of Bug #1333
+	 * https://www.varnish-cache.org/trac/ticket/1333
+	 * Note: this should only happen if the unsecure base url is configured to use https
+	 * @param string $url
+	 * @return string
+	 */
+	public function unsecureUrl($url) {
+		return preg_replace('!^https://!', 'http://', $url);
+	}
 }

--- a/app/code/community/Nexcessnet/Turpentine/Model/Observer/Esi.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Observer/Esi.php
@@ -256,7 +256,7 @@ class Nexcessnet_Turpentine_Model_Observer_Esi extends Varien_Event_Observer {
                 );
             }
 
-            $esiUrl = Mage::getUrl( 'turpentine/esi/getBlock', $urlOptions );
+            $esiUrl = $esiHelper->unsecureUrl(Mage::getUrl( 'turpentine/esi/getBlock', $urlOptions ));
             $blockObject->setEsiUrl( $esiUrl );
             // avoid caching the ESI template output to prevent the double-esi-
             // include/"ESI processing not enabled" bug


### PR DESCRIPTION
Force any ESI includes to use http rather than https since varnish does not support this as specified here: https://www.varnish-cache.org/trac/ticket/1333