### PR TITLE
Add layout_load_before event dispatching

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/controllers/EsiController.php
+++ b/app/code/community/Nexcessnet/Turpentine/controllers/EsiController.php
@@ -174,8 +174,15 @@ class Nexcessnet_Turpentine_EsiController extends Mage_Core_Controller_Front_Act
             ->setPackageName( $esiData->getDesignPackage() )
             ->setTheme( $esiData->getDesignTheme() );
         $layoutUpdate = $layout->getUpdate();
-        $layoutUpdate->load( $this->_swapCustomerHandles(
-            $esiData->getLayoutHandles() ) );
+        $layoutUpdate->addHandle($esiData->getLayoutHandles());
+
+        // dispatch event for adding handles to layout update
+        Mage::dispatchEvent(
+            'controller_action_layout_load_before',
+            array('action' => $this, 'layout'=> $layout)
+        );
+
+        $layoutUpdate->load();
         foreach( $esiData->getDummyBlocks() as $blockName ) {
             $layout->createBlock( 'Mage_Core_Block_Template', $blockName );
         }
@@ -205,25 +212,4 @@ class Nexcessnet_Turpentine_EsiController extends Mage_Core_Controller_Front_Act
         return $block;
     }
 
-    /**
-     * Swap customer_logged_in and customer_logged_out cached handles based on
-     * actual customer login status. Fixes stale Login/Logout links (and
-     * probably other things).
-     *
-     * This is definitely a hack, need a more general solution to this problem.
-     *
-     * @param  array $handles
-     * @return array
-     */
-    protected function _swapCustomerHandles( $handles ) {
-        if( Mage::helper( 'customer' )->isLoggedIn() ) {
-            $replacement = array( 'customer_logged_out', 'customer_logged_in' );
-        } else {
-            $replacement = array( 'customer_logged_in', 'customer_logged_out' );
-        }
-        if( ( $pos = array_search( $replacement[0], $handles ) ) !== false ) {
-            $handles[$pos] = $replacement[1];
-        }
-        return $handles;
-    }
 }

--- a/app/code/community/Nexcessnet/Turpentine/etc/config.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/config.xml
@@ -183,9 +183,9 @@
             <core_block_abstract_to_html_before>
                 <observers>
                     <turpentine_esi_core_block_abstract_to_html_before>
-                        <type>singleton</type>
                         <class>turpentine/observer_esi</class>
                         <method>injectEsi</method>
+                        <type>singleton</type>
                     </turpentine_esi_core_block_abstract_to_html_before>
                 </observers>
             </core_block_abstract_to_html_before>
@@ -194,10 +194,12 @@
                     <turpentine_esi_http_response_send_before>
                         <class>turpentine/observer_esi</class>
                         <method>setFlagHeaders</method>
+                        <type>singleton</type>
                     </turpentine_esi_http_response_send_before>
                     <turpentine_esi_replace_form_key_placeholder>
                         <class>turpentine/observer_esi</class>
                         <method>replaceFormKeyPlaceholder</method>
+                        <type>singleton</type>
                     </turpentine_esi_replace_form_key_placeholder>
                 </observers>
             </http_response_send_before>
@@ -206,6 +208,7 @@
                     <turpentine_esi_controller_action_layout_generate_blocks_after>
                         <class>turpentine/observer_esi</class>
                         <method>checkCacheFlag</method>
+                        <type>singleton</type>
                     </turpentine_esi_controller_action_layout_generate_blocks_after>
                 </observers>
             </controller_action_layout_generate_blocks_after>
@@ -219,9 +222,24 @@
                     <turpentine_esi_controller_response_redirect>
                         <class>turpentine/observer_esi</class>
                         <method>checkRedirectUrl</method>
+                        <type>singleton</type>
                     </turpentine_esi_controller_response_redirect>
                 </observers>
             </controller_response_redirect>
+
+            <!--
+            Save handles added by controller
+            This observer should be called first
+            -->
+            <controller_action_layout_load_before>
+                <observers>
+                    <aaaa_turpentine_esi_controller_response_redirect>
+                        <class>turpentine/observer_esi</class>
+                        <method>beforeLoadLayout</method>
+                        <type>singleton</type>
+                    </aaaa_turpentine_esi_controller_response_redirect>
+                </observers>
+            </controller_action_layout_load_before>
 
             <!--
             Load the ESI client cache clear events from stored config at
@@ -232,18 +250,22 @@
                     <turpentine_esi_controller_front_init_before>
                         <class>turpentine/observer_esi</class>
                         <method>loadCacheClearEvents</method>
+                        <type>singleton</type>
                     </turpentine_esi_controller_front_init_before>
                     <turpentine_esi_controller_front_init_before2>
                         <class>turpentine/observer_esi</class>
                         <method>addMessagesBlockRewrite</method>
+                        <type>singleton</type>
                     </turpentine_esi_controller_front_init_before2>
                     <turpentine_varnish_controller_front_init_before>
                         <class>turpentine/observer_varnish</class>
                         <method>addProductListToolbarRewrite</method>
+                        <type>singleton</type>
                     </turpentine_varnish_controller_front_init_before>
                     <turpentine_esi_set_replace_form_key_flag>
                         <class>turpentine/observer_esi</class>
                         <method>setReplaceFormKeyFlag</method>
+                        <type>singleton</type>
                     </turpentine_esi_set_replace_form_key_flag>
                 </observers>
             </controller_front_init_before>


### PR DESCRIPTION
Hi,

I have added layout load event dispatching to ESI Controller, so now extensions can add their handles to Layout Update in the same way as it works when you call `loadLayout` in controller.

I didn't really get how `_swapCustomerHandles` works, but with my fix `customer_logged_out` and `customer_logged_in` was added correctly.

Hard to say that it's the best solution, but it seems that there is no good solution at all :) This work for me.

Thanks in advance!