### PR TITLE
Issue #544. Improved 'fix_product_toolbar" setting

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Block/Catalog/Product/List/Toolbar.php
+++ b/app/code/community/Nexcessnet/Turpentine/Block/Catalog/Product/List/Toolbar.php
@@ -25,5 +25,10 @@ class Nexcessnet_Turpentine_Block_Catalog_Product_List_Toolbar extends
     public function _construct() {
         parent::_construct();
         $this->disableParamsMemorizing();
+        // Remove params that may have been memorized before this fix was active.
+        Mage::getSingleton('catalog/session')->unsSortOrder();
+        Mage::getSingleton('catalog/session')->unsSortDirection();
+        Mage::getSingleton('catalog/session')->unsDisplayMode();
+        Mage::getSingleton('catalog/session')->unsLimitPage();
     }
 }

--- a/app/code/community/Nexcessnet/Turpentine/etc/system.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/system.xml
@@ -94,7 +94,7 @@
                         </ajax_messages>
                         <fix_product_toolbar translate="label" module="turpentine">
                             <label>Fix Product List Toolbar</label>
-                            <comment>Enable this to prevent caching the products-per-page setting in the product list</comment>
+                            <comment>Enable this to prevent caching the visitor's view preferences of the product list</comment>
                             <frontend_type>select</frontend_type>
                             <source_model>turpentine/config_select_toggle</source_model>
                             <sort_order>65</sort_order>


### PR DESCRIPTION
I discovered the ''fix_product_toolbar" setting already fixed the sorting issue #544, except when the first visitor already has list view preferences stored in his catalog session. So I fixed that, and improved the setting's description.
