### PR TITLE
Folder fallback for configuration template file

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
@@ -105,8 +105,18 @@ abstract class Nexcessnet_Turpentine_Model_Varnish_Configurator_Abstract {
      * @return string
      */
     protected function _getVclTemplateFilename( $baseFilename ) {
-        $extensionDir = Mage::getModuleDir( '', 'Nexcessnet_Turpentine' );
-        return sprintf( '%s/misc/%s', $extensionDir, $baseFilename );
+        $fallback = array(
+            (string) Mage::getConfig()->getNode('global/turpentine_varnish/config_template'),
+            Mage::getBaseDir('app') . DS . 'etc' . DS . 'varnish'
+        );
+
+        foreach($fallback as $extensionDir) {
+            if($extensionDir && is_dir($extensionDir) && is_file($extensionDir . DS . $baseFilename)) {
+                return $extensionDir . DS . $baseFilename;
+            }
+        }
+
+        return Mage::getModuleDir( '', 'Nexcessnet_Turpentine' ) . DS . 'misc' . DS . $baseFilename;
     }
 
     /**


### PR DESCRIPTION
Hi,

I would like to be able to replace standard varnish config template without changing extension code. 

I have added simple fallback mechanism which check folder specified in XML, then `app/etc/varnish` and if template does not exists in any of these use `../Nexcessnet/Turpentine/misc`.

By default module always use it's own template file, but if you need to add/change something you can simply copy standard file to `app/etc/varnish` and make changes. If you have some special deployment process and need to be able to generate template outside of magento you can specify path in XML configuration, in the `global/turpentine_varnish/config_template` node.