### PR TITLE
changed the vcl regular expression for replacing multiple slashes in url...

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/misc/version-2.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-2.vcl
@@ -114,8 +114,9 @@ sub vcl_recv {
         return (pipe);
     }
 
-    # remove double slashes from the URL, for higher cache hit rate
-    set req.url = regsuball(req.url, "(.*)//+(.*)", "\1/\2");
+    # replace two or more sequential slashes in the url (before the query string)
+    # with a single slash, for a higher cache hit rate (url is used for hash)
+    set req.url = regsuball(req.url, "([^\?]*)//+(.*)", "\1/\2");
 
     {{normalize_encoding}}
     {{normalize_user_agent}}

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
@@ -115,8 +115,9 @@ sub vcl_recv {
         return (pipe);
     }
 
-    # remove double slashes from the URL, for higher cache hit rate
-    set req.url = regsuball(req.url, "(.*)//+(.*)", "\1/\2");
+    # replace two or more sequential slashes in the url (before the query string)
+    # with a single slash, for a higher cache hit rate (url is used for hash)
+    set req.url = regsuball(req.url, "([^\?]*)//+(.*)", "\1/\2");
 
     {{normalize_encoding}}
     {{normalize_user_agent}}


### PR DESCRIPTION
...s to not replace

any after ? (the querystring). This stops it breaking double slashes in query string parameters such
as urls being passed.
changed the wording of the comment, as it was slightly confusing (the regular expression replaced multiple slashes,
not just double slashes. added comment about exclusion of the query string.

see #645 
