### PR TITLE
Replace short open tag

### DIFF
--- a/contrib/tools/esi-decoder.php
+++ b/contrib/tools/esi-decoder.php
@@ -83,7 +83,7 @@ if ( $data ):
     <div class="result">
         <pre><?php echo htmlentities( $dataHelper->urlBase64Decode( $processData ) ); ?></pre>
     </div>
-<?
+<?php
     endif;
 endif;
 ?>


### PR DESCRIPTION
Replace short open tag to get rid of "unexpected end of file" message