### PR TITLE
Fix grace-period to work properly.

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/misc/version-2.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-2.vcl
@@ -98,6 +98,8 @@ sub vcl_recv {
             set req.http.X-Forwarded-For = client.ip;
         }
     }
+    # Set allowed grace period for current request
+    set req.grace = {{grace_period}}s;
 
     # varnish 2.1 doesn't support bare booleans so we have to add these
     # as headers to the req so they've available throught the VCL
@@ -256,7 +258,7 @@ sub vcl_hash {
 
 sub vcl_fetch {
     # set the grace period
-    set req.grace = {{grace_period}}s;
+    set beresp.grace = {{grace_period}}s;
 
     # Store the URL in the response object, we need this to do lurker friendly bans later
     set beresp.http.X-Varnish-Host = req.http.host;

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
@@ -105,6 +105,8 @@ sub vcl_recv {
             set req.http.X-Forwarded-For = client.ip;
         }
     }
+    # Set allowed grace period for current request
+    set req.grace = {{grace_period}}s;
 
     # We only deal with GET and HEAD by default
     # we test this here instead of inside the url base regex section
@@ -254,7 +256,7 @@ sub vcl_hit {
 
 sub vcl_fetch {
     # set the grace period
-    set req.grace = {{grace_period}}s;
+    set beresp.grace = {{grace_period}}s;
 
     # Store the URL in the response object, to be able to do lurker friendly bans later
     set beresp.http.X-Varnish-Host = req.http.host;


### PR DESCRIPTION
Current grace-period configuration doesn't really work. There was no beresp.grace in vcl_fetch, and req.grace should be moved to vcl_recv. In current version of Turpentine we can use only one feature of grace-period - delivering old content as long as fetching new content is in progress. Possibility to serve old content when backend is seek is possible only when BackendPooling is used - which can be introduced when we merge this pull request https://github.com/nexcess/magento-turpentine/pull/632 - which is really good job.

It can be easily test:

1. Set in Admin configuration "Grace period" for 1200s
2. Set in Admin configuration "Default Page TTL" to for example 60s
3. Clear varnish cache and upload new configuration to Varnish
4. Insert into your index.php at beggining some sleep display ```sleep(10)```
5. Call any page that will be cached (example www.clean-magento.local/index.php/sony-vaio-vgn-txn27n-b-11-1-notebook-pc.html)
6. Wait at least 60 seconds to make cache stale
7. Call ```curl -I www.clean-magento.local/index.php/sony-vaio-vgn-txn27n-b-11-1-notebook-pc.html``` in two seperate console
8. When one request will wait 10 sec, then second will get old content using grace-period