### PR TITLE
Replace connect20/nexcessnet_turpentine package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,9 @@
             "email": "aheadley@nexcess.net"
         }
     ],
+    "replace": {
+        "connect20/nexcessnet_turpentine": "self.version"
+    },
     "require": {
         "magento-hackathon/magento-composer-installer": "*"
     }


### PR DESCRIPTION
For now in [composer repository](http://packages.firegento.com/) we have same package from Magento Connect:
http://packages.firegento.com/#!/nexcessnet_turpentine

This module will replace it.

PS: I created [pull request](https://github.com/magento-hackathon/composer-repository/pull/128) to add this repository to composer repo