### PR TITLE
Fix license according to SPDX

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "nexcess/magento-turpentine",
     "type": "magento-module",
-    "license": "GPLv2+",
+    "license": "GPL-2.0+",
     "description": "A Varnish extension for Magento.",
     "homepage": "http://www.magentocommerce.com/magento-connect/2984.html",
     "authors": [


### PR DESCRIPTION
```
/composer.json is valid, but with a few warnings
See http://getcomposer.org/doc/04-schema.md for details on the schema
License "GPLv2+" is not a valid SPDX license identifier, see http://www.spdx.org/licenses/ if you use an open license.
```

Required for adding to [composer repo](https://github.com/magento-hackathon/composer-repository/pull/128)