### PR TITLE
Do not return pipe for OPTIONS straight away

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/misc/version-2.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-2.vcl
@@ -109,7 +109,7 @@ sub vcl_recv {
     # we test this here instead of inside the url base regex section
     # so we can disable caching for the entire site if needed
     if (req.http.X-Opt-Enable-Caching != "true" || req.http.Authorization ||
-            !(req.request ~ "^(GET|HEAD)$") ||
+            !(req.request ~ "^(GET|HEAD|OPTIONS)$") ||
             req.http.Cookie ~ "varnish_bypass={{secret_handshake}}") {
         return (pipe);
     }

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
@@ -110,7 +110,7 @@ sub vcl_recv {
     # we test this here instead of inside the url base regex section
     # so we can disable caching for the entire site if needed
     if (!{{enable_caching}} || req.http.Authorization ||
-        req.request !~ "^(GET|HEAD)$" ||
+        req.request !~ "^(GET|HEAD|OPTIONS)$" ||
         req.http.Cookie ~ "varnish_bypass={{secret_handshake}}") {
         return (pipe);
     }


### PR DESCRIPTION
An OPTIONS request require the X-Varnish-Secret-Handshake header to be set or it will return a 403 error, and prevent the request returning successfully. Breaking desired functionality of an ajax ESI block.