### PR TITLE
Fix messages returning a empty <ul />

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Block/Core/Messages.php
+++ b/app/code/community/Nexcessnet/Turpentine/Block/Core/Messages.php
@@ -204,6 +204,10 @@ class Nexcessnet_Turpentine_Block_Core_Messages extends Mage_Core_Block_Messages
             $html = $this->_real_toHtml();
         }
         $this->_directCall = false;
+
+        if (count($this->getMessages()) == 0) {
+            return '';
+        }
         return $html;
     }
 


### PR DESCRIPTION
I was finding that the messages block was returning

  <ul></ul>

Which was making a tad of a mess in my Layout, and it's bad HTML any.

This simple fix will return a blank string instead of a empty ul. Of course it's likely theme dependant anyway.