### PR TITLE
Fix messages returning a empty <ul />

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Block/Core/Messages.php
+++ b/app/code/community/Nexcessnet/Turpentine/Block/Core/Messages.php
@@ -204,6 +204,10 @@ class Nexcessnet_Turpentine_Block_Core_Messages extends Mage_Core_Block_Messages
             $html = $this->_real_toHtml();
         }
         $this->_directCall = false;
+
+        if (count($this->getMessages()) == 0) {
+            return '';
+        }
         return $html;
     }
 


### PR DESCRIPTION
As requested in https://github.com/nexcess/magento-turpentine/pull/814#issuecomment-114934759 reopening at devel instead of master