### PR TITLE
Possible work around for invalid form keys on first visit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: php
 
 php:
-    - 5.2
     - 5.3
     - 5.4
     - 5.5
+    - 5.6
 
 install:
     - sudo apt-get install -qq python-markdown libxml-xpath-perl build-essential

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -391,4 +391,5 @@ Magento CE 1.8+ or EE 1.13+, see [these instructions](https://github.com/nexcess
   * [#499] Use rewrite instead of local Session model for form key handling (@eth8505)  
   * [#817] Damian/cache management extended. Added validations for EE and Full Page cache (@damian-pastorini)
   * [#521] Fix for search input field on search results page (@jeroenvermeulen)
+  * Fix for recently viewed products block in CE 1.9.1 (Issue #801)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -393,3 +393,5 @@ Magento CE 1.8+ or EE 1.13+, see [these instructions](https://github.com/nexcess
   * [#521] Fix for search input field on search results page (@jeroenvermeulen)
   * Fix for recently viewed products block in CE 1.9.1 (Issue #801)
   * [#522] Custom log file (issue #510) (@eth8505)
+  * [#836] Add OS X .DS_Store and nbproject to gitignore (@cbb7123)
+  * [#832] Fixed duplicated frontend cookie bug (@mabigo)

--- a/app/design/frontend/base/default/layout/turpentine_esi.xml
+++ b/app/design/frontend/base/default/layout/turpentine_esi.xml
@@ -198,6 +198,20 @@
         </reference>
     </catalogsearch_result_index>
 
+    <!-- fixes issues with 'recently viewed products' in CE 1.9's RWD theme -->
+    <catalog_category_layered_nochildren>
+        <reference name="left.reports.product.viewed">
+                <action method="setEsiOptions">
+                    <params>
+                        <access>private</access>
+                        <flush_events>
+                            <catalog_controller_product_view/>
+                        </flush_events>
+                    </params>
+                </action>
+        </reference>
+    </catalog_category_layered_nochildren>
+
     <!-- Checkout -->
 
     <!-- We cache the checkout cart page on a per-client basis -->


### PR DESCRIPTION
In reference to Issue #315.

This is an early look/attempt to solving or at least creating a work around to the session problem that plagues Varnish and Turpentine in versions of Magento 1.8+ where a form key is used to validate a form in an attempt to secure the system against Cross Site Forgery Request.