### PR TITLE
Fix for HTTPS unsecure URLs in Magento breaking ESI includes

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Helper/Esi.php
+++ b/app/code/community/Nexcessnet/Turpentine/Helper/Esi.php
@@ -319,6 +319,19 @@ class Nexcessnet_Turpentine_Helper_Esi extends Mage_Core_Helper_Abstract {
     }
 
     /**
+     * Fix ESI URL to cover Varnish issues
+     *
+     * @param string $url ESI url
+     * @return string The corrected ESI url, or the original url if no changes needed
+     */
+    public function fixEsiUrl( $url ){
+        if(preg_match('/^https:\/\//i', $url)){
+            $url = 'http://' . substr($url, 8);
+        }
+        return $url;
+    }
+
+    /**
      * Generate an ESI tag to be replaced by the content from the given URL
      *
      * Generated tag looks like:
@@ -328,7 +341,7 @@ class Nexcessnet_Turpentine_Helper_Esi extends Mage_Core_Helper_Abstract {
      * @return string
      */
     public function buildEsiIncludeFragment( $url ) {
-        return sprintf( '<esi:include src="%s" />', $url );
+        return sprintf( '<esi:include src="%s" />', $this->fixEsiUrl( $url ) );
     }
 
     /**

--- a/app/code/community/Nexcessnet/Turpentine/Model/Observer/Esi.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Observer/Esi.php
@@ -286,6 +286,7 @@ class Nexcessnet_Turpentine_Model_Observer_Esi extends Varien_Event_Observer {
             }
 
             $esiUrl = Mage::getUrl( 'turpentine/esi/getBlock', $urlOptions );
+            $esiUrl = $esiHelper->fixEsiUrl( $esiUrl );
             $blockObject->setEsiUrl( $esiUrl );
             // avoid caching the ESI template output to prevent the double-esi-
             // include/"ESI processing not enabled" bug


### PR DESCRIPTION
When Magento has both secure and unsecure URLs specified with https:// (such as is done more regularly on new sites since Google started recommending full site SSL) Turpentine generates ESI URLs with https protocol. However, Varnish is not able to speak https and therefore parses these as relative URLs, causing webserver 404s and a severely broken store front.
Newer versions of Varnish (4+) appear to have an option to automatically convert these to http URLs, but as they are not compatible with Turpentine the fix must be made on the Magento end.

This patch introduces a fixEsiUrl method to the ESI helper that checks for https:// generated ESI URLs and internally replaces them with http://.

Related issues:
https://github.com/nexcess/magento-turpentine/issues/834
https://www.varnish-cache.org/trac/ticket/1333