### PR TITLE
Fix for HTTPS ESI URLs

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Helper/Esi.php
+++ b/app/code/community/Nexcessnet/Turpentine/Helper/Esi.php
@@ -357,7 +357,10 @@ class Nexcessnet_Turpentine_Helper_Esi extends Mage_Core_Helper_Abstract {
             $this->getEsiScopeParam()       => 'global',
             $this->getEsiCacheTypeParam()   => 'private',
         );
-        return Mage::getUrl( 'turpentine/esi/getFormKey', $urlOptions );
+        $esiUrl = Mage::getUrl( 'turpentine/esi/getFormKey', $urlOptions );
+        // setting [web/unsecure/base_url] can be https://... but ESI can never be HTTPS
+        $esiUrl = preg_replace( '|^https://|i', 'http://', $esiUrl );
+        return $esiUrl;
     }
 
     /**

--- a/app/code/community/Nexcessnet/Turpentine/Model/Observer/Esi.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Observer/Esi.php
@@ -286,6 +286,10 @@ class Nexcessnet_Turpentine_Model_Observer_Esi extends Varien_Event_Observer {
             }
 
             $esiUrl = Mage::getUrl( 'turpentine/esi/getBlock', $urlOptions );
+            if( $esiOptions[$methodParam] == 'esi' ) {
+                // setting [web/unsecure/base_url] can be https://... but ESI can never be HTTPS
+                $esiUrl = preg_replace( '|^https://|i', 'http://', $esiUrl );
+            }
             $blockObject->setEsiUrl( $esiUrl );
             // avoid caching the ESI template output to prevent the double-esi-
             // include/"ESI processing not enabled" bug


### PR DESCRIPTION
The config setting [web/unsecure/base_url] can be https://... but ESI can never be HTTPS.
Varnish 3 will treat HTTPS URLs as relative, leading to a 404 in Magento, leading to recursive ESI includes.