### PR TITLE
Allow to override initial cookie domain for multi-store setups

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
@@ -634,6 +634,26 @@ EOS;
     }
 
     /**
+     * Get the hostname for cookie normalization
+     *
+     * @return string
+     */
+    protected function _getNormalizeCookieTarget() {
+        return trim( Mage::getStoreConfig(
+            'turpentine_vcl/normalization/cookie_target' ) );
+    }
+
+    /**
+     * Get the regex for cookie normalization
+     *
+     * @return string
+     */
+    protected function _getNormalizeCookieRegex() {
+        return trim( Mage::getStoreConfig(
+            'turpentine_vcl/normalization/cookie_regex' ) );
+    }
+
+    /**
      * Build the list of template variables to apply to the VCL template
      *
      * @return array
@@ -686,7 +706,13 @@ EOS;
         if( Mage::getStoreConfig( 'turpentine_vcl/normalization/host' ) ) {
             $vars['normalize_host'] = $this->_vcl_sub_normalize_host();
         }
-
+        if( Mage::getStoreConfig( 'turpentine_vcl/normalization/cookie_regex' ) ) {
+            $vars['normalize_cookie_regex'] = $this->_getNormalizeCookieRegex();
+        }
+        if( Mage::getStoreConfig( 'turpentine_vcl/normalization/cookie_target' ) ) {
+            $vars['normalize_cookie_target'] = $this->_getNormalizeCookieTarget();
+        }
+        
         $customIncludeFile = $this->_getCustomIncludeFilename();
         if( is_readable( $customIncludeFile ) ) {
             $vars['custom_vcl_include'] = file_get_contents( $customIncludeFile );

--- a/app/code/community/Nexcessnet/Turpentine/etc/system.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/system.xml
@@ -336,6 +336,24 @@
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
                         </host_target>
+                        <cookie_regex translate="label" module="turpentine">
+                            <label>Normalize Cookie Regex</label>
+                            <comment>Cookie regex to match to override initial cookie domain</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>50</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </cookie_regex>
+                        <cookie_target translate="label" module="turpentine">
+                            <label>Normalized Cookie Target</label>
+                            <comment>Domain to force cookies to which the regex matches</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>60</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </cookie_target>
                     </fields>
                 </normalization>
                 <ttls translate="label" module="turpentine">


### PR DESCRIPTION
I have been using this code for quite some time to fix an issue with the initial cookie domain setting in VCL.

Basically if you have 2 or more stores e.g.
www.yourstore.co.uk
support.yourstore.co.uk
spares.yourstore.co.uk

With the default configuration for turpentine you will be given a cookie domain regardless of Magento's setting. So you will be given www.yourstore.co.uk domain, support.yourdomain etc.

However if you want to share cookies between those stores to take your basket with you, you need to set it something like: .yourdomain.co.uk which is not possible at the moment without this PR

This adds 2 additional options to the Turpentine settings:

Normalize Cookie Regex: - an example:  ^(www\.|spares\.|support\.)?yoursite\.co\.uk$
Normalized Cookie Target: .yoursite.co.uk

If the vhost matches one of the regex settings, then the cookie domain is overridden and it uses the cookie target instead.