### PR TITLE
escape | character

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Dummy/Request.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Dummy/Request.php
@@ -526,6 +526,7 @@ class Nexcessnet_Turpentine_Model_Dummy_Request extends
      * @return null
      */
     protected function _fixupFakeSuperGlobals( $uri ) {
+        $uri = str_replace('|', urlencode('|'), $uri);
         $parsedUrl = parse_url( $uri );
 
         if ( isset($parsedUrl['path']) ) {


### PR DESCRIPTION
Updated turpentine dummy request to fix unescaped '|' characters in URI 