### PR TITLE
[#832] bugfix, reg.url does not contain hostname (leads to permanent request pass, 0 hits)

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
@@ -158,7 +158,7 @@ sub vcl_recv {
             }
         }
         # if host is not allowed in magento pass to backend
-        if (req.url !~ "{{allowed_hosts_regex}}") {
+        if (req.http.host !~ "{{allowed_hosts_regex}}") {
         	return (pass);
         }
         # no frontend cookie was sent to us AND this is not an ESI or AJAX call


### PR DESCRIPTION
This is urgent fix for my previous commit. Hit/miss ratio is 0% when using reg.url, because it does not contain hostname i wanted to match against.