### PR TITLE
Add maintenance mode that will allow debug_ips through to visit the s…

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
@@ -663,7 +663,7 @@ EOS;
                 $tpl = <<<EOS
 if (req.http.X-Forwarded-For) {
     if(req.http.X-Forwarded-For !~ "{{debug_ips}}") {
-        return (synth(999, "Maintenance mode"));
+        error 503;
     }
 } else {
     if (client.ip !~ debug_acl) {

--- a/app/code/community/Nexcessnet/Turpentine/etc/system.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/system.xml
@@ -476,6 +476,35 @@
                         </exts>
                     </fields>
                 </static>
+                <maintenance translate="label" module="turpentine">
+                    <label>Maintenance mode</label>
+                    <frontend_type>text</frontend_type>
+                    <sort_order>46</sort_order>
+                    <show_in_default>1</show_in_default>
+                    <show_in_website>0</show_in_website>
+                    <show_in_store>0</show_in_store>
+                    <fields>
+                        <enable translate="label" module="turpentine">
+                            <label>Enable Maintenance Mode</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>turpentine/config_select_toggle</source_model>
+                            <comment>If enabled IP's not in 'developer client restrictions' will receive the following error page</comment>
+                            <sort_order>10</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </enable>
+                        <custom_vcl_synth translate="label" module="turpentine">
+                            <label>Custom HTML content of vcl synth (error) sub</label>
+                            <frontend_type>textarea</frontend_type>
+                            <comment>Enter full HTML page content</comment>
+                            <sort_order>20</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </custom_vcl_synth>
+                    </fields>
+                </maintenance>
             </groups>
         </turpentine_vcl>
     </sections>

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
@@ -97,6 +97,8 @@ sub generate_session_expires {
 ## Varnish Subroutines
 
 sub vcl_recv {
+	{{maintenance_allowed_ips}}
+
     # this always needs to be done so it's up at the top
     if (req.restarts == 0) {
         if (req.http.X-Forwarded-For) {
@@ -349,6 +351,8 @@ sub vcl_fetch {
     }
     # else it's not part of Magento so use the default Varnish handling
 }
+
+{{vcl_synth}}
 
 sub vcl_deliver {
     if (req.http.X-Varnish-Faked-Session) {


### PR DESCRIPTION
…ite, all other users get the landing page

Typically we want to take a store offline or put up a different holding page while we are doing maintenance. We can do this on our load balancer but at the moment this does not allow us to set a bespoke holding page.

What this does is allow us to create a bespoke holding page by editing the System->Config->Turpentine->Maintenance->VCL Synth which will get displayed to every one not maching the IP set in System->Config->Developer->Debug IPs

In VCL Synth you simply copy and paste your HTML into it.

This feature can be enabled or disabled via the setting Maintenance Mode Enabled Yes or No

All users outside this range will get the holding page without a backend fetch
All users matching the IP range will get the website.

You cannot do this with Magento - if you set the maintenance.flag everyone will get the holding page. If you use Varnish then this page then get's cached.

This gets around the issue for me.

This feature has been written to work on Varnish 3 and 4. I am using 4 primarily in my environment.