### PR TITLE
Removing nonexistent file from modman

### DIFF
--- a/modman
+++ b/modman
@@ -2,7 +2,6 @@
 
 app/etc/modules/Nexcessnet_Turpentine.xml       app/etc/modules/Nexcessnet_Turpentine.xml
 app/code/community/Nexcessnet/Turpentine/       app/code/community/Nexcessnet/Turpentine/
-app/code/local/Mage/Core/Model/Session.php      app/code/local/Mage/Core/Model/Session.php
 app/design/adminhtml/default/default/layout/turpentine.xml  app/design/adminhtml/default/default/layout/turpentine.xml
 app/design/adminhtml/default/default/template/turpentine/  app/design/adminhtml/default/default/template/turpentine/
 app/design/frontend/base/default/layout/turpentine_esi.xml   app/design/frontend/base/default/layout/turpentine_esi.xml


### PR DESCRIPTION
#499 removed app/code/local/Mage/Core/Model/Session.php in place of a rewrite, but didn't remove the reference to this file from modman. This is currently breaking composer installs in some cases.