### PR TITLE
Checkout Progress: Explicit Steps Needed

### DIFF
--- a/app/design/frontend/base/default/layout/turpentine_esi.xml
+++ b/app/design/frontend/base/default/layout/turpentine_esi.xml
@@ -240,6 +240,24 @@
         <turpentine_cache_flag value="0"/>
     </checkout_onepage_progress>
 
+    <checkout_onepage_progress_billing>
+        <turpentine_cache_flag value="0"/>
+    </checkout_onepage_progress_billing>
+
+    <checkout_onepage_progress_shipping>
+        <turpentine_cache_flag value="0"/>
+    </checkout_onepage_progress_shipping>
+
+    <checkout_onepage_progress_shipping_method>
+        <turpentine_cache_flag value="0"/>
+    </checkout_onepage_progress_shipping_method>
+
+    <checkout_onepage_progress_payment>
+        <turpentine_cache_flag value="0"/>
+    </checkout_onepage_progress_payment>
+
+
+
     <checkout_onepage_paymentmethod>
         <turpentine_cache_flag value="0"/>
     </checkout_onepage_paymentmethod>


### PR DESCRIPTION


I was doing some varnish troubleshooting for a client, and we ran into a situation, using Magento 1.9.0.1, where the cart checkout progress blocks were not bypassing the varnish cache.  We solved this by adding checkout to the turpentine blacklist -- but after investigating a bit I discovered the the approach turpentine takes to exclude checkout progress needs some tweaking.  This pull request is lightly tested -- so consider this more a bug report than anything else.

Also, seems related to @craigcarnell's problems in this ticket 
https://github.com/nexcess/magento-turpentine/issues/455

The basic problem is the `progressAction` method **doesn't** do a full layout load (`loadLayout`)

    #File: app/code/local/Mage/Checkout/controllers/OnepageController.php
    public function progressAction()
    {
        // previous step should never be null. We always start with billing and go forward
        $prevStep = $this->getRequest()->getParam('prevStep', false);

        if ($this->_expireAjax() || !$prevStep) {
            return null;
        }

        $layout = $this->getLayout();
        $update = $layout->getUpdate();
        /* Load the block belonging to the current step*/
        $update->load('checkout_onepage_progress_' . $prevStep);
        $layout->generateXml();
        $layout->generateBlocks();
        $output = $layout->getOutput();
        $this->getResponse()->setBody($output);
        
        return $output;
    }

Instead, it specifically loads **only** the progress handle it needs

    $prevStep = $this->getRequest()->getParam('prevStep', false);
    //...
    $update->load('checkout_onepage_progress_' . $prevStep);

Since `loadLayout` is never called, the `checkout_onepage_progress` handle(s) are never loaded into the layout and can't be applied.  This includes the all important handle in `turpentine_esi.xml`

    #File: app/design/frontend/base/default/layout/turpentine_esi.xml
    <checkout_onepage_progress>
        <turpentine_cache_flag value="0"/>
    </checkout_onepage_progress>
    
This pull request attempts a crude fix by being explicit about the progress handles to exclude. Another approach might be a pre-action dispatch listener that manually loads the `checkout_onepage_progress` handle in the layout -- I'm never sure how fancy to get in other people's projects :)
