### PR TITLE
Fix for viewed/compared blocks #801, #803

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Block/Product/Compared.php
+++ b/app/code/community/Nexcessnet/Turpentine/Block/Product/Compared.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Nexcess.net Turpentine Extension for Magento
+ * Copyright (C) 2012  Nexcess.net L.L.C.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+class Nexcessnet_Turpentine_Block_Product_Compared extends Mage_Reports_Block_Product_Compared {
+
+    protected function _toHtml()
+    {
+        if (!$this->getCount()) {
+            return $this->renderView();
+        }
+
+        $this->setRecentlyComparedProducts($this->getItemsCollection());
+
+        return parent::_toHtml();
+    }
+}

--- a/app/code/community/Nexcessnet/Turpentine/Block/Product/Viewed.php
+++ b/app/code/community/Nexcessnet/Turpentine/Block/Product/Viewed.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Nexcess.net Turpentine Extension for Magento
+ * Copyright (C) 2012  Nexcess.net L.L.C.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+class Nexcessnet_Turpentine_Block_Product_Viewed extends Mage_Reports_Block_Product_Viewed {
+
+    protected function _toHtml()
+    {
+        if (!$this->getCount()) {
+            return $this->renderView();
+        }
+        $this->setRecentlyViewedProducts($this->getItemsCollection());
+        return parent::_toHtml();
+    }
+}

--- a/app/code/community/Nexcessnet/Turpentine/etc/config.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/config.xml
@@ -131,6 +131,18 @@
                     <activePoll>Nexcessnet_Turpentine_Block_Poll_ActivePoll</activePoll>
                 </rewrite>
             </poll>
+
+            <!--
+            Rewrite the compared and viewed product block. Default behavior returns '' if 
+            no items to display, which prevents display of the ESI url, causing caching problems
+            -->
+            <reports>
+                <rewrite>
+                    <product_compared>Nexcessnet_Turpentine_Block_Product_Compared</product_compared>
+                    <product_viewed>Nexcessnet_Turpentine_Block_Product_Viewed</product_viewed>
+                </rewrite>
+            </reports>
+
             <adminhtml>
                 <rewrite>
                     <cache_grid>Nexcessnet_Turpentine_Block_Adminhtml_Cache_Grid</cache_grid>

--- a/app/design/frontend/base/default/layout/turpentine_esi.xml
+++ b/app/design/frontend/base/default/layout/turpentine_esi.xml
@@ -88,6 +88,8 @@
                     <access>private</access>
                     <flush_events>
                         <catalog_product_compare_add_product/>
+                        <catalog_product_compare_remove_product/>
+                        <catalog_product_compare_item_collection_clear/>
                     </flush_events>
                 </params>
             </action>


### PR DESCRIPTION
This should fix the issues with the 'viewed products' and 'recently compared products' https://github.com/nexcess/magento-turpentine/issues/803 and https://github.com/nexcess/magento-turpentine/issues/801

The core problem is that the magento core blocks return nothing if there are no items appropriate for the block. That makes some sense, but it prevents the Turpentine *toHtml()* function from inserting the ESI call into the page for these blocks in that situation.