### PR TITLE
Pull request #825 broke the ESI messages. This commit fixes it.

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Block/Core/Messages.php
+++ b/app/code/community/Nexcessnet/Turpentine/Block/Core/Messages.php
@@ -198,16 +198,17 @@ class Nexcessnet_Turpentine_Block_Core_Messages extends Mage_Core_Block_Messages
             } else {
                 $this->_loadMessages();
                 $this->_loadSavedMessages();
-                $html = $this->_real_toHtml();
+                if ( count($this->getMessages()) ) {
+                    $html = $this->_real_toHtml();
+                } else {
+                    // Prevent returning an empty <ul></ul>
+                    $html = '';
+                }
             }
         } else {
             $html = $this->_real_toHtml();
         }
         $this->_directCall = false;
-
-        if (count($this->getMessages()) == 0) {
-            return '';
-        }
         return $html;
     }
 


### PR DESCRIPTION
When there were no messages, but there was HTML for the ESI container, it was thrown away by code from PR #825. When that happened, there was no ESI container on that page, so messages would never work on that cached page.
This fix is quite urgent since ESI flash messages are broken in the current master branch.