### PR TITLE
Fix for version detection on socket when connecting

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Admin/Socket.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Admin/Socket.php
@@ -345,7 +345,9 @@ class Nexcessnet_Turpentine_Model_Varnish_Admin_Socket {
                 $banner['text'] );
         }
 
-        $this->_version = $this->_determineVersion($banner['text']);
+        if ($this->_version == null) { // If autodetecting
+            $this->_version = $this->_determineVersion($banner['text']);
+        }
 
         return $this->isConnected();
     }


### PR DESCRIPTION
Set to use Magento config specified version when available.

This fixes the issue causing the VCL compilation to default to an incorrect version, I was getting the version 2.1 template on my Varnish 3.0 install.

This fixes ticket #908