### PR TITLE
Resolve Bad URI when parsing q/search parameters

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Dummy/Request.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Dummy/Request.php
@@ -38,6 +38,9 @@ class Nexcessnet_Turpentine_Model_Dummy_Request extends
      * @throws Zend_Controller_Request_Exception when invalid URI passed
      */
     public function __construct( $uri=null ) {
+        // deals with Search Parameters (q) that include ' ' when decoded and passed to this function
+        $uri = str_replace(' ', '+', $uri);
+
         $this->_initFakeSuperGlobals();
         $this->_fixupFakeSuperGlobals( $uri );
         try {


### PR DESCRIPTION
```2015-09-01T13:43:06+00:00 ERR (3): TURPENTINE: Bad URI given to dummy request: http://SOMEWEBSITE/catalogsearch/result/index/?q=copper wire mesh```

Consider this message.

Zend is rejecting the ` ` space character in the `q` query string argument.

The simplest fix I could determine as to shove a semi dirty patch in to convert ` ` back to `+` in the URI in the constructor of Dummy request