### PR TITLE
DetermineVersion 3.0 to 3.0.3 bugfix

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Admin/Socket.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Admin/Socket.php
@@ -357,7 +357,13 @@ class Nexcessnet_Turpentine_Model_Varnish_Admin_Socket {
             Mage::throwException('Varnish versions before 2.1 are not supported');
         }
         if ( count($bannerText)<7 ) {
-            // Varnish before 3.0 does not spit out a version number
+            // Varnish before 3.0.4 does not spit out a version number
+            $resp = $this->_write( 'help' )->_read();
+            if( strpos( $resp['text'], 'ban.url' ) !== false ) {
+                // Varnish versions 3.0 through 3.0.3 do not return a version banner. 
+                // To differentiate between 2.1 and 3.0, we check the existence of the ban.url command.
+                return '3.0';
+            }
             return '2.1';
         } elseif ( preg_match(self::REGEXP_VARNISH_VERSION, $bannerText[4], $matches)===1 ) {
             return $matches['vmajor'] . '.' . $matches['vminor'];


### PR DESCRIPTION
Related to: https://github.com/nexcess/magento-turpentine/issues/918

The versioned banner of Varnish is introduced in Varnish version 3.0.4. In version 3.0 to 3.0.3, the banned has the same behaviour as version 2.1.

Turpentine version 0.6.4 to 0.6.5 has changed the autodetection of the Varnish version. This causes problems in autodetecting the version of varnish 3.0 to 3.0.3. These version will be recognized as version 2.1. The VCL of 2.1 is not compatible with 3.0, which will cause a crash of varnish on reboot or restart.

This Pull-request reverts a small code of 0.6.4 determineVersion https://github.com/nexcess/magento-turpentine/blob/release-0.6.4/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Admin/Socket.php#L490.

Varnish 3.0.2 is provided by Debian Wheezy or Ubuntu 12.04 by default. So turpentine will not automatically work on these distros by default.

There is another fix around (https://github.com/nexcess/magento-turpentine/pull/915), where you have to set the varnish version by hand. I would prefer the autodetect version, so we can make it our customers a bit easier to setup their Varnish with Turpentine environment. 