### PR TITLE
#924 - Added support for caching for publick pages in order to reduce…

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
@@ -559,6 +559,27 @@ EOS;
     }
 
     /**
+     * Checks if guest caching should be used
+     *
+     * @return bool
+     */
+    protected function _getGuestCachingFlag()
+    {
+        return Mage::getStoreConfig( 'turpentine_varnish/general/guest_caching_enable' )
+            ? 'true' : 'false';
+    }
+
+    /**
+     * Converts guest caching black list values in format we can use in VCL file
+     *
+     * @return string
+     */
+    protected function _getGuestCachingBlacklist() {
+        $urls = Mage::getStoreConfig( 'turpentine_varnish/general/guest_caching_blacklist' );
+        return implode( '|', Mage::helper( 'turpentine/data' )->cleanExplode( PHP_EOL, $urls ));
+    }
+
+    /**
      * Remove empty and commented out lines from the generated VCL
      *
      * @param  string $dirtyVcl generated vcl
@@ -872,6 +893,8 @@ EOS;
                 $this->_getVclTemplateFilename( self::VCL_CUSTOM_C_CODE_FILE ) ),
             'esi_private_ttl'   => Mage::helper( 'turpentine/esi' )
                 ->getDefaultEsiTtl(),
+            'guest_caching_enable' => $this->_getGuestCachingFlag(),
+            'guest_caching_blacklist' => $this->_getGuestCachingBlacklist(),
         );
 
         if( (bool)Mage::getStoreConfig( 'turpentine_vcl/urls/bypass_cache_store_url') ) {

--- a/app/code/community/Nexcessnet/Turpentine/etc/config.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/config.xml
@@ -35,6 +35,12 @@
                 <fix_product_toolbar>0</fix_product_toolbar>
                 <crawler_enable>0</crawler_enable>
                 <crawler_debug>0</crawler_debug>
+                <guest_caching_enable>1</guest_caching_enable>
+                <guest_caching_blacklist><![CDATA[\.html
+customer/
+review/product/
+catalog/product/view/
+checkout/]]></guest_caching_blacklist>
             </general>
             <logging>
                 <use_custom_log_file>0</use_custom_log_file>

--- a/app/code/community/Nexcessnet/Turpentine/etc/system.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/system.xml
@@ -132,6 +132,28 @@
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
                         </crawler_debug>
+                        <guest_caching_enable translate="label" module="turpentine">
+                            <label>Guest Caching</label>
+                            <comment>Enable to allow Turpentine cache pages where usually customers do not need session. When Enabled all guest customers get frontend=guest-customer-session until they do not hit url that contains "Guest Caching Blacklist Url Part"</comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>turpentine/config_select_toggle</source_model>
+                            <sort_order>90</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </guest_caching_enable>
+                        <guest_caching_blacklist translate="label" module="turpentine">
+                            <label>Guest Caching Blacklist Url Parts</label>
+                            <depends>
+                                <guest_caching_enable>1</guest_caching_enable>
+                            </depends>
+                            <frontend_type>textarea</frontend_type>
+                            <comment>If request url matches any string of this list then the customer will get real session and guest caching would not work for this customer.</comment>
+                            <sort_order>100</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </guest_caching_blacklist>
                     </fields>
                 </general>
                 <logging translate="label" module="turpentine">
@@ -530,7 +552,7 @@
                             <sort_order>10</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
-                            <show_in_store>0</show_in_store>                        
+                            <show_in_store>0</show_in_store>
                         </get_params>
                         <ignore_get_params translate="label" module="turpentine">
                             <label>Ignore GET Parameters</label>


### PR DESCRIPTION
… the number of backend calls when customer visits shop for first time. Adding frontend cookie = guest-customer-session and deleting it when customer reaches non public page. For example product page.