### PR TITLE
Send unmodified url to the backend server

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
@@ -380,6 +380,14 @@ EOS;
     }
 
     /**
+     * @return boolean
+     */
+    protected function _sendUnModifiedUrlToBackend()
+    {
+        return Mage::getStoreConfigFlag('turpentine_vcl/params/transfer_unmodified_url');
+    }
+
+    /**
      * Get the Generate Session
      *
      * @return string
@@ -844,6 +852,7 @@ EOS;
             'default_ttl'   => $this->_getDefaultTtl(),
             'enable_get_excludes'   => ($this->_getGetParamExcludes() ? 'true' : 'false'),
             'enable_get_ignored' => ($this->_getIgnoreGetParameters() ? 'true' : 'false'),
+            'send_unmodified_url' => ($this->_sendUnModifiedUrlToBackend() ? 'true' : 'false'),
             'debug_headers' => $this->_getEnableDebugHeaders(),
             'grace_period'  => $this->_getGracePeriod(),
             'force_cache_static'    => $this->_getForceCacheStatic(),

--- a/app/code/community/Nexcessnet/Turpentine/etc/config.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/config.xml
@@ -80,6 +80,7 @@
             <params>
                 <get_params>__SID,XDEBUG_PROFILE</get_params>
                 <ignore_get_params>utm_source,utm_medium,utm_campaign,utm_content,utm_term,gclid,cx,ie,cof,siteurl</ignore_get_params>
+                <transfer_unmodified_url>0</transfer_unmodified_url>
             </params>
             <static>
                 <force_static>1</force_static>

--- a/app/code/community/Nexcessnet/Turpentine/etc/system.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/system.xml
@@ -541,6 +541,20 @@
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
                         </ignore_get_params>
+                        <transfer_unmodified_url translate="label" module="extendedvarnish">
+                            <label>Transfer unmodified URL to Backend Server</label>
+                            <comment>
+                                By default the backend server (webserver / magento) gets a modified URL (without ignored get parameters).
+                                As a result the ignored parameters can not be used by the backend server for uncachable requests, for example a redirect.
+                                By activating this option the backend server gets the the unmodified url, but the cache still uses the modified url for lookups.
+                            </comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>21</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </transfer_unmodified_url>
                     </fields>
                 </params>
                 <static translate="label" module="turpentine">

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
@@ -121,6 +121,11 @@ sub vcl_recv {
         return (pipe);
     }
 
+    if({{send_unmodified_url}}) {
+        # save the unmodified url
+        set req.http.X-Varnish-Origin-Url = req.url;
+    }
+
     # remove double slashes from the URL, for higher cache hit rate
     set req.url = regsuball(req.url, "(.*)//+(.*)", "\1/\2");
 
@@ -206,6 +211,12 @@ sub vcl_recv {
             set req.url = regsuball(req.url, "(?:(\?)&|\?$)", "\1");
         }
 
+        if({{send_unmodified_url}}) {
+            set req.http.X-Varnish-Cache-Url = req.url;
+            set req.url = req.http.X-Varnish-Origin-Url;
+            unset req.http.X-Varnish-Origin-Url;
+        }
+
         # everything else checks out, try and pull from the cache
         return (hash);
     }
@@ -225,7 +236,13 @@ sub vcl_pipe {
 # }
 
 sub vcl_hash {
-    hash_data(req.url);
+
+    if({{send_unmodified_url}} && req.http.X-Varnish-Cache-Url) {
+        hash_data(req.http.X-Varnish-Cache-Url);
+    } else {
+        hash_data(req.url);
+    }
+
     if (req.http.Host) {
         hash_data(req.http.Host);
     } else {


### PR DESCRIPTION
Hi,

I've fixed my own Issue #935 ;) . It is an optional feature so it will not change the behaviour after an update. Configuration field is here: ``System > Configuration > Turpentine > Caching Options > Parameter-based Caching > Transfer unmodified URL to Backend Server``. 

### Technical details

* The backend server gets the unmodified url (``req.url``)
* Modified url (stripped google parameters...) is saved in ``req.http.X-Varnish-Cache-Url``
*  ``req.http.X-Varnish-Cache-Url`` will be used for cache lookups in ``vcl_hash``

=> The cache hit rate should not be impacted by the changes and the backend server gets accesss to the unmodified url for uncachable requests like rewrites.    



