### PR TITLE
Include theme specific handles to ESI data

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Observer/Esi.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Observer/Esi.php
@@ -376,9 +376,9 @@ class Nexcessnet_Turpentine_Model_Observer_Esi extends Varien_Event_Observer {
                 // check if this handle has any block or reference tags that
                 // refer to this block or a child block, unless the handle name
                 // is blank
-                if( $handle !== '' &&
+                if( $handle !== '' && ( strpos($handle, 'THEME') === 0 ||
                     $layoutXml->xpath( sprintf(
-                        '//%s//*[@name=\'%s\']', $handle, $blockName ) ) ) {
+                        '//%s//*[@name=\'%s\']', $handle, $blockName ) ) ) ) {
                     $activeHandles[] = $handle;
                 }
             }


### PR DESCRIPTION
Allows layout update data to be cached based on design themes. You can then have device specific widgets based off of the theme match expressions in ESI calls.