### PR TITLE
only return pipe when vcl_fix is enabled

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
@@ -415,7 +415,7 @@ EOS;
      */
     protected function _getGenerateSession() {
         return Mage::getStoreConfig( 'turpentine_varnish/general/vcl_fix' )
-            ? '# call generate_session' : 'call generate_session;';
+            ? 'return (pipe);' : 'call generate_session;';
     }
 
 

--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
@@ -414,7 +414,7 @@ EOS;
      * @return string
      */
     protected function _getGenerateSession() {
-        return Mage::getStoreConfig( 'turpentine_varnish/general/vcl_fix' )
+        return Mage::getStoreConfigFlag( 'turpentine_varnish/general/vcl_fix' )
             ? 'return (pipe);' : 'call generate_session;';
     }
 

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
@@ -177,8 +177,7 @@ sub vcl_recv {
                 set req.http.Cookie = "frontend=crawler-session";
             } else {
                 # it's a real user, make up a new session for them
-                {{generate_session}}# call generate_session;
-                return (pipe);
+                {{generate_session}}
             }
         }
         if ({{force_cache_static}} &&

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
@@ -21,7 +21,7 @@ vcl 4.0;
 ## Custom C Code
 
 C{
-    # @source app/code/community/Nexcessnet/Turpentine/misc/uuid.c
+    // @source app/code/community/Nexcessnet/Turpentine/misc/uuid.c
     {{custom_c_code}}
 }C
 
@@ -175,8 +175,7 @@ sub vcl_recv {
                 set req.http.Cookie = "frontend=crawler-session";
             } else {
                 # it's a real user, make up a new session for them
-                {{generate_session}}# call generate_session;
-                return (pipe);
+                {{generate_session}}
             }
         }
         if ({{force_cache_static}} &&


### PR DESCRIPTION
When vcl_fix was introduced, return pipe was used. This should only be when generate_session was never called.. I think..