### PR TITLE
#971 - Fixed bug with wrong return value of ->getSkinUrl() in ESI con…

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Observer/Esi.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Observer/Esi.php
@@ -325,7 +325,7 @@ class Nexcessnet_Turpentine_Model_Observer_Esi extends Varien_Event_Observer {
         $methodParam = $esiHelper->getEsiMethodParam();
         $esiData = new Varien_Object();
         $esiData->setStoreId( Mage::app()->getStore()->getId() );
-        $esiData->setDesignPackage( Mage::getDesign()->getPackageName() );
+        $esiData->setNameInLayout( $blockObject->getNameInLayout() );
         $esiData->setBlockType( get_class( $blockObject ) );
         $esiData->setLayoutHandles( $this->_getBlockLayoutHandles( $blockObject ) );
         $esiData->setEsiMethod( $esiOptions[$methodParam] );

--- a/app/code/community/Nexcessnet/Turpentine/Model/Observer/Esi.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Observer/Esi.php
@@ -326,8 +326,6 @@ class Nexcessnet_Turpentine_Model_Observer_Esi extends Varien_Event_Observer {
         $esiData = new Varien_Object();
         $esiData->setStoreId( Mage::app()->getStore()->getId() );
         $esiData->setDesignPackage( Mage::getDesign()->getPackageName() );
-        $esiData->setDesignTheme( Mage::getDesign()->getTheme( 'layout' ) );
-        $esiData->setNameInLayout( $blockObject->getNameInLayout() );
         $esiData->setBlockType( get_class( $blockObject ) );
         $esiData->setLayoutHandles( $this->_getBlockLayoutHandles( $blockObject ) );
         $esiData->setEsiMethod( $esiOptions[$methodParam] );

--- a/app/code/community/Nexcessnet/Turpentine/controllers/EsiController.php
+++ b/app/code/community/Nexcessnet/Turpentine/controllers/EsiController.php
@@ -183,9 +183,6 @@ class Nexcessnet_Turpentine_EsiController extends Mage_Core_Controller_Front_Act
             }
         }
         $layout = Mage::getSingleton( 'core/layout' );
-        Mage::getSingleton( 'core/design_package' )
-            ->setPackageName( $esiData->getDesignPackage() )
-            ->setTheme( $esiData->getDesignTheme() );
 
         // dispatch event for adding handles to layout update
         Mage::dispatchEvent(


### PR DESCRIPTION
Because we have "store_id" in ESI data we don't need to pass:
```
$esiData->setDesignPackage( Mage::getDesign()->getPackageName() );
$esiData->setDesignTheme( Mage::getDesign()->getTheme( 'layout' ) );
```

In Nexcessnet_Turpentine_EsiController we have:
```
Mage::app()->setCurrentStore(Mage::app()->getStore( $esiData->getStoreId() ) );
```
this is the reason why we don't need:
```
Mage::getSingleton( 'core/design_package' )
  ->setPackageName( $esiData->getDesignPackage() )
  ->setTheme( $esiData->getDesignTheme() );
```

Because in this case Magento knows "store_id" then correct design package, skin path, layout path and etc. will be taken from configuration for this "store_id" ... no need those values to be passed through ESI data.