### PR TITLE
Add the form key to wishlist submit to prevent 403 errors.

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Observer/Esi.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Observer/Esi.php
@@ -532,6 +532,9 @@ class Nexcessnet_Turpentine_Model_Observer_Esi extends Varien_Event_Observer {
         if(Mage::helper( 'turpentine/data')->getVclFix() == 0 && $observer->getEvent()->getControllerAction()->getFullActionName() == 'checkout_cart_add') {
             Mage::dispatchEvent("add_to_cart_before", array('request' => $observer->getControllerAction()->getRequest()));
         }
+        if ($observer->getEvent()->getControllerAction()->getFullActionName() == 'wishlist_index_index') {
+            Mage::dispatchEvent('wishlist_index_index_before', array('request' => $observer->getControllerAction()->getRequest()));
+        }
     }
 
     public function hookToControllerActionPostDispatch($observer) {
@@ -551,5 +554,19 @@ class Nexcessnet_Turpentine_Model_Observer_Esi extends Varien_Event_Observer {
     public function hookToAddToCartAfter($observer) {
         $request = $observer->getEvent()->getRequest()->getParams();
         //Mage::log("hookToAddToCartAfter ".print_r($request,true)." is added to cart.", null, 'carrinho.log', true);
+    }
+
+    /**
+     * Set the form key on the add to wishlist request
+     *
+     * @param $observer
+     *
+     * @return Nexcessnet_Turpentine_Model_Observer_Esi
+     */
+    public function hookToAddToWishlistBefore($observer)
+    {
+        $key = Mage::getSingleton('core/session')->getFormKey();
+        $observer->getEvent()->getRequest()->setParam('form_key', $key);
+        return $this;
     }
 }

--- a/app/code/community/Nexcessnet/Turpentine/etc/config.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/config.xml
@@ -468,6 +468,14 @@
                     </add_to_cart_after>
                 </observers>
             </add_to_cart_after-->
+            <wishlist_index_index_before>
+                <observers>
+                    <wishlist_index_index_before>
+                        <class>turpentine/observer_esi</class>
+                        ><method>hookToAddToWishlistBefore</method>
+                    </wishlist_index_index_before>
+                </observers>
+            </wishlist_index_index_before>
         </events>
     </frontend>
     <admin>


### PR DESCRIPTION
Adds the form key to the request when viewing the wishlist page. This prevents '403' issues when adding a wishlist product to the basket (see https://github.com/nexcess/magento-turpentine/issues/497)

If there's a better way of doing this then please let me know as it appears the add to basket issue has been solved in the VCL.