### PR TITLE
Improved helper function getModelName()

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Helper/Data.php
+++ b/app/code/community/Nexcessnet/Turpentine/Helper/Data.php
@@ -231,12 +231,20 @@ class Nexcessnet_Turpentine_Helper_Data extends Mage_Core_Helper_Abstract {
      * @param  string|object $model
      * @return string
      */
-    public function getModelName($model) {
-        if (is_object($model)) {
-            $model = get_class($model);
+    public function getModelName( $model ) {
+        if( is_object( $model ) ) {
+            $model = get_class( $model );
         }
-        return strtolower(preg_replace(
-            '~^[^_]+_([^_]+)_Model_(.+)$~', '$1/$2', $model ));
+        // This guess may work if the extension uses its lowercased name as model group name.
+        $result = strtolower( preg_replace(
+            '~^[^_]+_([^_]+)_Model_(.+)$~', '$1/$2', $model ) );
+        // This check is not expensive because the answer should come from Magento's classNameCache
+        $checkModel = Mage::getConfig()->getModelClassName($result);
+        if ( 'Mage_' == substr($checkModel,0,5) && !class_exists($result) ) {
+            // Fallback to full model name.
+            $result = $model;
+        }
+        return $result;
     }
 
     /**


### PR DESCRIPTION
The function `Mage::helper('turpentine/data')->getModelName($product);` did not work in case an extension used in config.xml:
```xml
    <models>
        <mygroupname>
            <class>MyPackage_MyExtension_Model</class>
        <mygroupname>
        <catalog>
            <rewrite>
                <product>MyPackage_MyExtension_Model_Product</product>
            </rewrite>
        </catalog>
    </models>
```
Because then the class guessed by `getModelName($product)` was `myextension/product` while it should be `mygroupname/product`.
I made the function check if the guessed value is a valid model name. 
If not valid: the right value is quite hard to look up, so I decided to return the full class name, `MyPackage_MyExtension_Model_Product` in this example.