### PR TITLE
"Use Simple Hash" option for static files

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
@@ -440,6 +440,16 @@ EOS;
     }
 
     /**
+     * Get the Force Static Caching option
+     *
+     * @return string
+     */
+    protected function _getSimpleHashStatic() {
+        return Mage::getStoreConfig('turpentine_vcl/static/simple_hash')
+            ? 'true' : 'false';
+    }
+
+    /**
      * Format the list of static cache extensions
      *
      * @return string
@@ -942,6 +952,7 @@ EOS;
             'debug_headers' => $this->_getEnableDebugHeaders(),
             'grace_period'  => $this->_getGracePeriod(),
             'force_cache_static'    => $this->_getForceCacheStatic(),
+            'simple_hash_static'    => $this->_getSimpleHashStatic(),
             'generate_session_expires'    => $this->_getGenerateSessionExpires(),
             'generate_session'    => $this->_getGenerateSession(),
             'generate_session_start'    => $this->_getGenerateSessionStart(),

--- a/app/code/community/Nexcessnet/Turpentine/etc/config.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/config.xml
@@ -85,6 +85,7 @@
             <static>
                 <force_static>1</force_static>
                 <exts>css,js,jpe?g,png,gif,ico,swf</exts>
+                <simple_hash>1</simple_hash>
             </static>
         </turpentine_vcl>
     </default>

--- a/app/code/community/Nexcessnet/Turpentine/etc/system.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/system.xml
@@ -587,6 +587,19 @@
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
                         </exts>
+                        <simple_hash translate="label" module="turpentine">
+                            <label>Use Simple Hash</label>
+                            <comment>Always serve the same version of a static file. Ignore domain, cookies and browser version. Saves memory and lowers cache misses.</comment>
+                            <depends>
+                                <force_static>1</force_static>
+                            </depends>
+                            <frontend_type>select</frontend_type>
+                            <source_model>turpentine/config_select_toggle</source_model>
+                            <sort_order>30</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </simple_hash>
                     </fields>
                 </static>
                 <maintenance translate="label" module="turpentine">

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
@@ -183,6 +183,7 @@ sub vcl_recv {
             # don't need cookies for static assets
             unset req.http.Cookie;
             unset req.http.X-Varnish-Faked-Session;
+            set req.http.X-Varnish-Static = 1;
             return (hash);
         }
         # this doesn't need a enable_url_excludes because we can be reasonably
@@ -237,6 +238,16 @@ sub vcl_pipe {
 # }
 
 sub vcl_hash {
+    # For static files we keep the hash simple and don't add the domain.
+    # This saves memory when a static file is used on multiple domains.
+    if ({{simple_hash_static}} && req.http.X-Varnish-Static) {
+        hash_data(req.url);
+        if (req.http.Accept-Encoding) {
+            # make sure we give back the right encoding
+            hash_data(req.http.Accept-Encoding);
+        }
+        return (lookup);
+    }
 
     if({{send_unmodified_url}} && req.http.X-Varnish-Cache-Url) {
         hash_data(req.http.X-Varnish-Cache-Url);


### PR DESCRIPTION
When enabled: Always serve the same version of a static file. Ignore domain, cookies and browser version. Saves memory and lowers cache misses.
Thanks to @toonvd for the idea of this improvement.

Fixed some use of bare booleans in Varnish 2.1 config