### PR TITLE
Fix for crawler lock problem with CM_RedisSession

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Observer/Varnish.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Observer/Varnish.php
@@ -56,6 +56,22 @@ class Nexcessnet_Turpentine_Model_Observer_Varnish extends Varien_Event_Observer
     }
 
     /**
+     * Turpentine sets the fake cookie 'frontend=crawler-session' when a crawler is detected.
+     * This causes lock problems with Cm_RedisSession, because all crawler hits are requesting the same session lock.
+     * Cm_RedisSession provides the define CM_REDISSESSION_LOCKING_ENABLED to overrule if locking should be enabled.
+     *
+     * @param $eventObject
+     * @return null
+     */
+    public function fixCmRedisSessionLocks($eventObject) {
+        if (Mage::helper('core')->isModuleEnabled('Cm_RedisSession')) {
+            if (!empty($_COOKIE['frontend']) && 'crawler-session' == $_COOKIE['frontend']) {
+                define('CM_REDISSESSION_LOCKING_ENABLED', false);
+            }
+        }
+    }
+
+    /**
      * Re-apply and save Varnish configuration on config change
      *
      * @param  mixed $eventObject

--- a/app/code/community/Nexcessnet/Turpentine/etc/config.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/config.xml
@@ -302,6 +302,10 @@
                         <class>turpentine/observer_varnish</class>
                         <method>addProductListToolbarRewrite</method>
                     </turpentine_varnish_controller_front_init_before>
+                    <turpentine_varnish_fix_cm_redissession_locks>
+                        <class>turpentine/observer_varnish</class>
+                        <method>fixCmRedisSessionLocks</method>
+                    </turpentine_varnish_fix_cm_redissession_locks>
                     <turpentine_esi_set_replace_form_key_flag>
                         <class>turpentine/observer_esi</class>
                         <method>setReplaceFormKeyFlag</method>


### PR DESCRIPTION
Turpentine sets the fake cookie 'frontend=crawler-session' when a crawler is detected.
This causes lock problems with Cm_RedisSession, because all crawler hits are requesting the same session lock.
Cm_RedisSession provides the define CM_REDISSESSION_LOCKING_ENABLED to overrule if locking should be enabled.
I added an 'controller_front_init_before' event listener to set this define if the fake session cookie exists.