### PR TITLE
Fix regex check - blank value passed check

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
@@ -390,7 +390,7 @@ sub vcl_deliver {
                 "; domain=" + regsub(req.http.Host, ":\d+$", "");
             } else {
                 # it's a real user, allow sharing of cookies between stores
-                if(req.http.Host ~ "{{normalize_cookie_regex}}") {
+                if (req.http.Host ~ "{{normalize_cookie_regex}}" && "{{normalize_cookie_regex}}" ~ "..")
                     set resp.http.Set-Cookie = resp.http.Set-Cookie +
                     "; domain={{normalize_cookie_target}}";
                 } else {


### PR DESCRIPTION
This seems to fix https://github.com/nexcess/magento-turpentine/issues/1075

`req.http.Host ~ "{{normalize_cookie_regex}}"` was evaluating to true if no cookie normalize regular expression is set in the back-end, triggering a cookie being set w/no domain. 

The fix requires the normalize regular expression to have at least two characters.