### PR TITLE
add ability to throttle crawler requests

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Helper/Cron.php
+++ b/app/code/community/Nexcessnet/Turpentine/Helper/Cron.php
@@ -146,6 +146,24 @@ class Nexcessnet_Turpentine_Helper_Cron extends Mage_Core_Helper_Abstract {
     }
 
     /**
+     * Get number of urls to crawl per batch
+     *
+     * @return int
+     */
+    public function getCrawlerBatchSize() {
+        return Mage::getStoreConfig('turpentine_varnish/general/crawler_batchsize');
+    }
+
+    /**
+     * Get time in seconds to wait between url batches
+     *
+     * @return int
+     */
+    public function getCrawlerWaitPeriod() {
+        return Mage::getStoreConfig('turpentine_varnish/general/crawler_batchwait');
+    }
+
+    /**
      * Get the list of all URLs
      *
      * @return array

--- a/app/code/community/Nexcessnet/Turpentine/Model/Observer/Cron.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Observer/Cron.php
@@ -66,7 +66,7 @@ class Nexcessnet_Turpentine_Model_Observer_Cron extends Varien_Event_Observer {
                 if ($crawlCount > 0
                     && $timeout > 0
                     && $batchSize > 0
-                    && $crawlCount%$batchSize == 0
+                    && $crawlCount % $batchSize == 0
                 ) {
                     Mage::helper('turpentine/debug')->logDebug('Crawled '.$crawlCount.' urls, sleeping for '.$timeout.' seconds');
                     sleep($timeout);

--- a/app/code/community/Nexcessnet/Turpentine/Model/Observer/Cron.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Observer/Cron.php
@@ -49,6 +49,11 @@ class Nexcessnet_Turpentine_Model_Observer_Cron extends Varien_Event_Observer {
             if ($maxRunTime === 0) {
                 $maxRunTime = self::MAX_CRAWL_TIME;
             }
+
+            $batchSize = $helper->getCrawlerBatchSize();
+            $timeout = $helper->getCrawlerWaitPeriod();
+            $crawlCount = 0;
+
             // just in case we have a silly short max_execution_time
             $maxRunTime = abs($maxRunTime - self::EXEC_TIME_BUFFER);
             while (($helper->getRunTime() < $maxRunTime) &&
@@ -57,6 +62,16 @@ class Nexcessnet_Turpentine_Model_Observer_Cron extends Varien_Event_Observer {
                     Mage::helper('turpentine/debug')->logWarn(
                         'Failed to crawl URL: %s', $url );
                 }
+
+                if ($crawlCount > 0
+                    && $timeout > 0
+                    && $batchSize > 0
+                    && $crawlCount%$batchSize == 0
+                ) {
+                    Mage::helper('turpentine/debug')->logDebug('Crawled '.$crawlCount.' urls, sleeping for '.$timeout.' seconds');
+                    sleep($timeout);
+                }
+                $crawlCount++;
             }
         }
     }

--- a/app/code/community/Nexcessnet/Turpentine/etc/config.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/config.xml
@@ -35,6 +35,8 @@
                 <fix_product_toolbar>0</fix_product_toolbar>
                 <crawler_enable>0</crawler_enable>
                 <crawler_debug>0</crawler_debug>
+                <crawler_batchsize>10</crawler_batchsize>
+                <crawler_batchwait>0</crawler_batchwait>
             </general>
             <logging>
                 <use_custom_log_file>0</use_custom_log_file>

--- a/app/code/community/Nexcessnet/Turpentine/etc/config.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/config.xml
@@ -35,7 +35,7 @@
                 <fix_product_toolbar>0</fix_product_toolbar>
                 <crawler_enable>0</crawler_enable>
                 <crawler_debug>0</crawler_debug>
-                <crawler_batchsize>10</crawler_batchsize>
+                <crawler_batchsize>0</crawler_batchsize>
                 <crawler_batchwait>0</crawler_batchwait>
             </general>
             <logging>

--- a/app/code/community/Nexcessnet/Turpentine/etc/system.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/system.xml
@@ -132,6 +132,30 @@
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
                         </crawler_debug>
+                        <crawler_batchsize translate="label" module="turpentine">
+                            <label>Crawler Batch Size</label>
+                            <comment>Number of URLs to crawl per crawler batch. Set to 0 for unlimited</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>90</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                            <depends>
+                                <crawler_enable>1</crawler_enable>
+                            </depends>
+                        </crawler_batchsize>
+                        <crawler_batchwait translate="label" module="turpentine">
+                            <label>Crawler Batch Wait</label>
+                            <comment>Time in seconds to wait between URL batches</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>100</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                            <depends>
+                                <crawler_enable>1</crawler_enable>
+                            </depends>
+                        </crawler_batchwait>
                     </fields>
                 </general>
                 <logging translate="label" module="turpentine">

--- a/app/code/community/Nexcessnet/Turpentine/etc/system.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/system.xml
@@ -134,7 +134,7 @@
                         </crawler_debug>
                         <crawler_batchsize translate="label" module="turpentine">
                             <label>Crawler Batch Size</label>
-                            <comment>Number of URLs to crawl per crawler batch. Set to 0 for unlimited</comment>
+                            <comment>Number of URLs to crawl per batch, when 0 requests will not be batched</comment>
                             <frontend_type>text</frontend_type>
                             <sort_order>90</sort_order>
                             <show_in_default>1</show_in_default>
@@ -146,7 +146,7 @@
                         </crawler_batchsize>
                         <crawler_batchwait translate="label" module="turpentine">
                             <label>Crawler Batch Wait</label>
-                            <comment>Time in seconds to wait between URL batches</comment>
+                            <comment>Time in seconds to wait between batches</comment>
                             <frontend_type>text</frontend_type>
                             <sort_order>100</sort_order>
                             <show_in_default>1</show_in_default>


### PR DESCRIPTION
On smaller servers the volume of crawler requests can use up resources. This commit adds the ability to throttle the crawler by sleeping after a given number of requests, giving the server a chance to cool down.
