### PR TITLE
Allow custom VCL includes in top and bottom of generated vcl

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
@@ -130,10 +130,21 @@ abstract class Nexcessnet_Turpentine_Model_Varnish_Configurator_Abstract {
      *
      * @return string
      */
-    protected function _getCustomIncludeFilename() {
+    protected function _getCustomIncludeBottomFilename() {
         return $this->_formatTemplate(
-            Mage::getStoreConfig('turpentine_varnish/servers/custom_include_file'),
-            array('root_dir' => Mage::getBaseDir()) );
+            Mage::getStoreConfig('turpentine_varnish/servers/custom_include_file_bottom'),
+            array('root_dir' => Mage::getBaseDir()));
+    }
+
+    /**
+     * Get the name of the custom include VCL file
+     *
+     * @return string
+     */
+    protected function _getCustomIncludeTopFilename() {
+        return $this->_formatTemplate(
+            Mage::getStoreConfig('turpentine_varnish/servers/custom_include_file_top'),
+            array('root_dir' => Mage::getBaseDir()));
     }
 
     /**
@@ -1007,9 +1018,14 @@ EOS;
             $vars['vcl_synth'] = $this->_vcl_sub_synth();
         }
 
-        $customIncludeFile = $this->_getCustomIncludeFilename();
-        if (is_readable($customIncludeFile)) {
-            $vars['custom_vcl_include'] = file_get_contents($customIncludeFile);
+        $customIncludeTopFile = $this->_getCustomIncludeTopFilename();
+        if (is_readable($customIncludeTopFile)) {
+            $vars['custom_vcl_include_top'] = file_get_contents($customIncludeTopFile);
+        }
+
+        $customIncludeBottomFile = $this->_getCustomIncludeBottomFilename();
+        if (is_readable($customIncludeBottomFile)) {
+            $vars['custom_vcl_include_bottom'] = file_get_contents($customIncludeBottomFile);
         }
 
         return $vars;

--- a/app/code/community/Nexcessnet/Turpentine/etc/config.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/config.xml
@@ -44,7 +44,8 @@
                 <version>auto</version>
                 <server_list>127.0.0.1:6082</server_list>
                 <config_file>{{root_dir}}/var/default.vcl</config_file>
-                <custom_include_file>{{root_dir}}/app/code/community/Nexcessnet/Turpentine/misc/custom_include.vcl</custom_include_file>
+                <custom_include_file_top>{{root_dir}}/app/code/community/Nexcessnet/Turpentine/misc/custom_include_top.vcl</custom_include_file_top>
+                <custom_include_file_bottom>{{root_dir}}/app/code/community/Nexcessnet/Turpentine/misc/custom_include_bottom.vcl</custom_include_file_bottom>
             </servers>
         </turpentine_varnish>
         <turpentine_vcl>

--- a/app/code/community/Nexcessnet/Turpentine/etc/config.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/config.xml
@@ -45,7 +45,7 @@
                 <server_list>127.0.0.1:6082</server_list>
                 <config_file>{{root_dir}}/var/default.vcl</config_file>
                 <custom_include_file_top>{{root_dir}}/app/code/community/Nexcessnet/Turpentine/misc/custom_include_top.vcl</custom_include_file_top>
-                <custom_include_file_bottom>{{root_dir}}/app/code/community/Nexcessnet/Turpentine/misc/custom_include_bottom.vcl</custom_include_file_bottom>
+                <custom_include_file_bottom>{{root_dir}}/app/code/community/Nexcessnet/Turpentine/misc/custom_include.vcl</custom_include_file_bottom>
             </servers>
         </turpentine_varnish>
         <turpentine_vcl>

--- a/app/code/community/Nexcessnet/Turpentine/etc/system.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/system.xml
@@ -209,15 +209,24 @@
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
                         </config_file>
-                        <custom_include_file translate="label" module="turpentine">
-                            <label>Custom VCL File Location</label>
+                        <custom_include_file_top translate="label" module="turpentine">
+                            <label>Top Custom VCL File Location</label>
                             <frontend_type>text</frontend_type>
-                            <comment>Specify where the Varnish VCL customization file should be saved</comment>
+                            <comment>Specify where the Varnish VCL customization file should be saved. Will be included at the top of the generated vcl file</comment>
                             <sort_order>40</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
-                        </custom_include_file>
+                        </custom_include_file_top>
+                        <custom_include_file_bottom translate="label" module="turpentine">
+                            <label>Bottom Custom VCL File Location</label>
+                            <frontend_type>text</frontend_type>
+                            <comment>Specify where the Varnish VCL customization file should be saved. Will be included at the bottom of the generated vcl file</comment>
+                            <sort_order>50</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </custom_include_file_bottom>
                     </fields>
                 </servers>
             </groups>

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-2.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-2.vcl
@@ -26,7 +26,7 @@ C{
 
 ## Custom VCL Logic
 
-{{custom_vcl_include}}
+{{custom_vcl_include_top}}
 
 ## Backends
 
@@ -426,3 +426,8 @@ sub vcl_deliver {
     }
     remove resp.http.X-Opt-Debug-Headers;
 }
+
+
+## Custom VCL Logic
+
+{{custom_vcl_include_bottom}}

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
@@ -28,6 +28,10 @@ C{
 
 import std;
 
+## Custom VCL Logic
+
+{{custom_vcl_include_bottom}}
+
 ## Backends
 
 {{default_backend}}
@@ -433,5 +437,5 @@ sub vcl_deliver {
 
 ## Custom VCL Logic
 
-{{custom_vcl_include}}
+{{custom_vcl_include_bottom}}
 

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
@@ -30,7 +30,7 @@ import std;
 
 ## Custom VCL Logic
 
-{{custom_vcl_include_bottom}}
+{{custom_vcl_include_top}}
 
 ## Backends
 

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
@@ -29,6 +29,10 @@ C{
 
 import std;
 
+## Custom VCL Logic
+
+{{custom_vcl_include_top}}
+
 ## Backends
 
 {{default_backend}}
@@ -434,4 +438,4 @@ sub vcl_deliver {
 
 ## Custom VCL Logic
 
-{{custom_vcl_include}}
+{{custom_vcl_include_bottom}}


### PR DESCRIPTION
This commit adds the ability to add custom vcl files to both the top and bottom of the generated vcl file. I added this as I was having issues adding custom logic to the vcl_recv subroutine. I believe this is because the turpentine subroutine is called first and returns at the end so the bottom one is never actually called. I was simply going to add the include to the top of the file but it seems that the include has been recently moved to the bottom, I am sure this was for a good reason. 

This problem was also mentioned [here](https://github.com/nexcess/magento-turpentine/issues/1083), I have implemented the discussed changed in this pull request.
