### PR TITLE
Add option for pre-include vcl

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
@@ -130,9 +130,19 @@ abstract class Nexcessnet_Turpentine_Model_Varnish_Configurator_Abstract {
      *
      * @return string
      */
-    protected function _getCustomIncludeFilename() {
+    protected function _getCustomPostIncludeFilename() {
         return $this->_formatTemplate(
             Mage::getStoreConfig('turpentine_varnish/servers/custom_include_file'),
+            array('root_dir' => Mage::getBaseDir()) );
+    }
+
+    /**
+     * @return string
+     */
+    protected function _getCustomPreIncludefilename()
+    {
+        return $this->_formatTemplate(
+            Mage::getStoreConfig('turpentine_varnish/servers/custom_pre_include_file'),
             array('root_dir' => Mage::getBaseDir()) );
     }
 
@@ -1007,9 +1017,14 @@ EOS;
             $vars['vcl_synth'] = $this->_vcl_sub_synth();
         }
 
-        $customIncludeFile = $this->_getCustomIncludeFilename();
-        if (is_readable($customIncludeFile)) {
-            $vars['custom_vcl_include'] = file_get_contents($customIncludeFile);
+        $customPreIncludeFilename = $this->_getCustomPreIncludeFilename();
+        if (is_readable($customPreIncludeFilename)) {
+            $vars['custom_vcl_pre_include'] = file_get_contents($customPreIncludeFilename);
+        }
+
+        $customPostIncludeFilename = $this->_getCustomPostIncludeFilename();
+        if (is_readable($customPostIncludeFilename)) {
+            $vars['custom_vcl_include'] = file_get_contents($customPostIncludeFilename);
         }
 
         return $vars;

--- a/app/code/community/Nexcessnet/Turpentine/etc/config.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/config.xml
@@ -45,6 +45,7 @@
                 <server_list>127.0.0.1:6082</server_list>
                 <config_file>{{root_dir}}/var/default.vcl</config_file>
                 <custom_include_file>{{root_dir}}/app/code/community/Nexcessnet/Turpentine/misc/custom_include.vcl</custom_include_file>
+                <custom_pre_include_file>{{root_dir}}/app/code/community/Nexcessnet/Turpentine/misc/custom_pre_include.vcl</custom_pre_include_file>
             </servers>
         </turpentine_varnish>
         <turpentine_vcl>

--- a/app/code/community/Nexcessnet/Turpentine/etc/system.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/system.xml
@@ -209,6 +209,15 @@
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
                         </config_file>
+                        <custom_pre_include_file translate="label" module="turpentine">
+                            <label>Custom Pre include VCL File Location</label>
+                            <frontend_type>text</frontend_type>
+                            <comment>Specify where the Varnish VCL customization file should be saved</comment>
+                            <sort_order>40</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </custom_pre_include_file>
                         <custom_include_file translate="label" module="turpentine">
                             <label>Custom VCL File Location</label>
                             <frontend_type>text</frontend_type>

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-2.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-2.vcl
@@ -40,6 +40,10 @@ C{
 
 {{debug_acl}}
 
+## Custom Pre Include VCL Logic
+
+{{custom_vcl_pre_include}}
+
 ## Custom Subroutines
 
 sub generate_session {

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
@@ -40,6 +40,11 @@ import std;
 
 {{debug_acl}}
 
+## Custom Pre Include VCL Logic
+
+{{custom_vcl_pre_include}}
+
+
 ## Custom Subroutines
 
 {{generate_session_start}}

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
@@ -41,6 +41,10 @@ import std;
 
 {{debug_acl}}
 
+## Custom Pre Include VCL Logic
+
+{{custom_vcl_pre_include}}
+
 ## Custom Subroutines
 
 {{generate_session_start}}


### PR DESCRIPTION
The plugin currently supports extra logic at the bottom of the built-in template. This PR add the option to add custom vcl logic before the main block at higher priority.
