### PR TITLE
fix broken cms page override for theme

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Observer/Esi.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Observer/Esi.php
@@ -325,6 +325,8 @@ class Nexcessnet_Turpentine_Model_Observer_Esi extends Varien_Event_Observer {
         $methodParam = $esiHelper->getEsiMethodParam();
         $esiData = new Varien_Object();
         $esiData->setStoreId(Mage::app()->getStore()->getId());
+        $esiData->setDesignPackage( Mage::getDesign()->getPackageName() );
+        $esiData->setDesignTheme( Mage::getDesign()->getTheme( 'layout' ) );
         $esiData->setNameInLayout($blockObject->getNameInLayout());
         $esiData->setBlockType(get_class($blockObject));
         $esiData->setLayoutHandles($this->_getBlockLayoutHandles($blockObject));

--- a/app/code/community/Nexcessnet/Turpentine/controllers/EsiController.php
+++ b/app/code/community/Nexcessnet/Turpentine/controllers/EsiController.php
@@ -183,6 +183,9 @@ class Nexcessnet_Turpentine_EsiController extends Mage_Core_Controller_Front_Act
             }
         }
         $layout = Mage::getSingleton('core/layout');
+        Mage::getSingleton( 'core/design_package' )
+                ->setPackageName( $esiData->getDesignPackage() )
+                ->setTheme( $esiData->getDesignTheme() );
 
         // dispatch event for adding handles to layout update
         Mage::dispatchEvent(


### PR DESCRIPTION
A previous commit removed the following code. Without it it's impossible to override a theme for a CMS page.
