### PR TITLE
Feature: Custom file include on top of VLC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build/*.tgz
 build/*.html
-app/code/community/Nexcessnet/Turpentine/misc/custom_include.vcl
+app/code/community/Nexcessnet/Turpentine/misc/custom_include*.vcl
+*~
 .idea
 .DS_Store
 nbproject/

--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
@@ -130,9 +130,11 @@ abstract class Nexcessnet_Turpentine_Model_Varnish_Configurator_Abstract {
      *
      * @return string
      */
-    protected function _getCustomIncludeFilename() {
+    protected function _getCustomIncludeFilename($position='') {
+        $key = 'custom_include_file';
+        $key .= ($position) ? '_'.$position : '';
         return $this->_formatTemplate(
-            Mage::getStoreConfig('turpentine_varnish/servers/custom_include_file'),
+            Mage::getStoreConfig('turpentine_varnish/servers/'.$key),
             array('root_dir' => Mage::getBaseDir()) );
     }
 
@@ -1007,9 +1009,13 @@ EOS;
             $vars['vcl_synth'] = $this->_vcl_sub_synth();
         }
 
-        $customIncludeFile = $this->_getCustomIncludeFilename();
-        if (is_readable($customIncludeFile)) {
-            $vars['custom_vcl_include'] = file_get_contents($customIncludeFile);
+        foreach (array('','top') as $position) {
+            $customIncludeFile = $this->_getCustomIncludeFilename($position);
+            if (is_readable($customIncludeFile)) {
+                $key = 'custom_vcl_include';
+                $key .= ($position) ? '_'.$position : '';
+                $vars[$key] = file_get_contents($customIncludeFile);
+            }
         }
 
         return $vars;

--- a/app/code/community/Nexcessnet/Turpentine/etc/config.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/config.xml
@@ -47,6 +47,7 @@
                 <server_list>127.0.0.1:6082</server_list>
                 <config_file>{{root_dir}}/var/default.vcl</config_file>
                 <custom_include_file>{{root_dir}}/app/code/community/Nexcessnet/Turpentine/misc/custom_include.vcl</custom_include_file>
+                <custom_include_file_top>{{root_dir}}/app/code/community/Nexcessnet/Turpentine/misc/custom_include_top.vcl</custom_include_file_top>
             </servers>
         </turpentine_varnish>
         <turpentine_vcl>

--- a/app/code/community/Nexcessnet/Turpentine/etc/system.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/system.xml
@@ -233,11 +233,20 @@
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
                         </config_file>
-                        <custom_include_file translate="label" module="turpentine">
-                            <label>Custom VCL File Location</label>
+                        <custom_include_file_top translate="label" module="turpentine">
+                            <label>Custom VCL File - Top</label>
                             <frontend_type>text</frontend_type>
-                            <comment>Specify where the Varnish VCL customization file should be saved</comment>
+                            <comment>If this file exists, its content will be prepended to the VCL.</comment>
                             <sort_order>40</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </custom_include_file_top>
+                        <custom_include_file translate="label" module="turpentine">
+                            <label>Custom VCL File - Bottom</label>
+                            <frontend_type>text</frontend_type>
+                            <comment>If this file exists, its content will be appended to the VCL.</comment>
+                            <sort_order>41</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-2.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-2.vcl
@@ -17,10 +17,6 @@
 
 ## Nexcessnet_Turpentine Varnish v2 VCL Template
 
-## Custom VCL Logic - Top
-
-{{custom_vcl_include_top}}
-
 ## Custom C Code
 
 C{
@@ -28,6 +24,9 @@ C{
     {{custom_c_code}}
 }C
 
+## Custom VCL Logic - Top
+
+{{custom_vcl_include_top}}
 
 ## Backends
 

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-2.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-2.vcl
@@ -17,6 +17,10 @@
 
 ## Nexcessnet_Turpentine Varnish v2 VCL Template
 
+## Custom VCL Logic - Top
+
+{{custom_vcl_include_top}}
+
 ## Custom C Code
 
 C{
@@ -24,9 +28,6 @@ C{
     {{custom_c_code}}
 }C
 
-## Custom VCL Logic
-
-{{custom_vcl_include}}
 
 ## Backends
 
@@ -426,3 +427,7 @@ sub vcl_deliver {
     }
     remove resp.http.X-Opt-Debug-Headers;
 }
+
+## Custom VCL Logic - Bottom
+
+{{custom_vcl_include}}

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
@@ -17,6 +17,10 @@
 
 ## Nexcessnet_Turpentine Varnish v3 VCL Template
 
+## Custom VCL Logic - Top
+
+{{custom_vcl_include_top}}
+
 ## Custom C Code
 
 C{
@@ -431,7 +435,7 @@ sub vcl_deliver {
     }
 }
 
-## Custom VCL Logic
+## Custom VCL Logic - Bottom
 
 {{custom_vcl_include}}
 

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
@@ -17,10 +17,6 @@
 
 ## Nexcessnet_Turpentine Varnish v3 VCL Template
 
-## Custom VCL Logic - Top
-
-{{custom_vcl_include_top}}
-
 ## Custom C Code
 
 C{
@@ -31,6 +27,10 @@ C{
 ## Imports
 
 import std;
+
+## Custom VCL Logic - Top
+
+{{custom_vcl_include_top}}
 
 ## Backends
 

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
@@ -18,10 +18,6 @@ vcl 4.0;
 
 ## Nexcessnet_Turpentine Varnish v4 VCL Template
 
-## Custom VCL Logic - Top
-
-{{custom_vcl_include_top}}
-
 ## Custom C Code
 
 C{
@@ -33,6 +29,10 @@ C{
 
 import std;
 import directors;
+
+## Custom VCL Logic - Top
+
+{{custom_vcl_include_top}}
 
 ## Backends
 

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
@@ -18,6 +18,10 @@ vcl 4.0;
 
 ## Nexcessnet_Turpentine Varnish v4 VCL Template
 
+## Custom VCL Logic - Top
+
+{{custom_vcl_include_top}}
+
 ## Custom C Code
 
 C{
@@ -432,6 +436,6 @@ sub vcl_deliver {
     }
 }
 
-## Custom VCL Logic
+## Custom VCL Logic - Bottom
 
 {{custom_vcl_include}}


### PR DESCRIPTION
When multiple subroutines with the same name exist in Varnish, they get concatenated.
The existing 'custom_include.vcl' file is appended to the VCL. It can't be used to expand the 'sub vcl_recv' because the existing one contains 'return (pipe)' statements. Whatever you add will not be executed in a lot of situations.
I added a 'custom_include_top.vcl' file, which is prepended to the VCL. This allows you to override everything. For example you can include a 'return (pipe)' yourself to skip the default Turpentine VCL :-)