### PR TITLE
Fix for issue #1093 - poll still displaying when module output disabled

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Block/Poll/ActivePoll.php
+++ b/app/code/community/Nexcessnet/Turpentine/Block/Poll/ActivePoll.php
@@ -21,11 +21,19 @@
 
 class Nexcessnet_Turpentine_Block_Poll_ActivePoll extends Mage_Poll_Block_ActivePoll {
 
-    public function setTemplate($template)
-    {
-        $this->_template = $template;
-        $this->setPollTemplate('turpentine/ajax.phtml', 'poll');
-        $this->setPollTemplate('turpentine/ajax.phtml', 'results');
-        return $this;
-    }
+	public function setTemplate($template)
+	{
+		if ((Mage::getConfig()->getModuleConfig('Mage_Poll')->is('active', 'true')) &&
+		(!Mage::getStoreConfig('advanced/modules_disable_output/Mage_Poll')))
+		{
+			$this->_template = $template;
+			$this->setPollTemplate('turpentine/ajax.phtml', 'poll');
+			$this->setPollTemplate('turpentine/ajax.phtml', 'results');
+		}
+		else
+		{
+			// Mage_Poll is disabled, so do nothing
+		}
+		return $this;
+	}
 }


### PR DESCRIPTION
Now checks to make sure the Mage_Poll module is active and doesn't have it's output disabled to fix https://github.com/nexcess/magento-turpentine/issues/1093 (poll block showing up even if the module output is disabled in the backend).