### PR TITLE
#1213: Generate global blocks like formkey for ESI-Blocks

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/controllers/EsiController.php
+++ b/app/code/community/Nexcessnet/Turpentine/controllers/EsiController.php
@@ -253,6 +253,15 @@ class Nexcessnet_Turpentine_EsiController extends Mage_Core_Controller_Front_Act
                 $layout->generateBlocks($node);
             }
         }
+        if ($roots = $layout->getNode()->xpath('//block[@name=\'root\']')) {
+            foreach (array('formkey') as $globalBlock) {
+                if ($blocks = $layout->getNode()->xpath(sprintf('//block[@name=\'%s\']', $globalBlock))) {
+                    $dummy = $roots[0]->addChild('reference');
+                    $dummy->appendChild($blocks[0]);
+                    $layout->generateBlocks($dummy);
+                }
+            }
+        }
         $block = $layout->getBlock($esiData->getNameInLayout());
 
         if ( ! $this->getFlag('', self::FLAG_NO_DISPATCH_BLOCK_EVENT)) {


### PR DESCRIPTION
Issue #1213

Create a virtual <reference>-node, append the global formkey-block-node (if found) and call $layout->generateBlocks on it. That way $layout->getBlockHtml() can be called within ESI-Blocks.