### PR TITLE
Add option to log all Varnish commands

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Admin/Socket.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Admin/Socket.php
@@ -499,6 +499,9 @@ class Nexcessnet_Turpentine_Model_Varnish_Admin_Socket {
                 "Got unexpected response code from Varnish: %d\n%s",
                 $response['code'], $response['text'] ));
         } else {
+            if (Mage::getStoreConfig('turpentine_varnish/general/varnish_log_commands')) { 
+                Mage::helper('turpentine/debug')->logDebug('VARNISH command sent: ' . $data);
+            }
             return $response;
         }
     }

--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
@@ -110,8 +110,8 @@ abstract class Nexcessnet_Turpentine_Model_Varnish_Configurator_Abstract {
      * @return string
      */
     protected function _getVclTemplateFilename($baseFilename) {
-        $extensionDir = Mage::getModuleDir('', 'Nexcessnet_Turpentine');
-        return sprintf('%s/misc/%s', $extensionDir, $baseFilename);
+           $extensionDir = Mage::getModuleDir('', 'Nexcessnet_Turpentine');
+           return sprintf('%s/misc/%s', $extensionDir, $baseFilename);
     }
 
     /**
@@ -135,6 +135,23 @@ abstract class Nexcessnet_Turpentine_Model_Varnish_Configurator_Abstract {
             Mage::getStoreConfig('turpentine_varnish/servers/custom_include_file'),
             array('root_dir' => Mage::getBaseDir()) );
     }
+
+
+    /**
+     * Get the custom VCL template, if it exists
+     * Returns 'null' if the file doesn't exist
+     *
+     * @return string
+     */
+    protected function _getCustomTemplateFilename() {
+        $filePath = $this->_formatTemplate(
+            Mage::getStoreConfig('turpentine_varnish/servers/custom_vcl_template'),
+            array('root_dir' => Mage::getBaseDir())
+        );
+        if (is_file($filePath)) { return $filePath; }
+        else { return null; }
+    }
+
 
     /**
      * Format a template string, replacing {{keys}} with the appropriate values

--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Version3.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Version3.php
@@ -31,7 +31,14 @@ class Nexcessnet_Turpentine_Model_Varnish_Configurator_Version3
      * @return string
      */
     public function generate($doClean = true) {
-        $tplFile = $this->_getVclTemplateFilename(self::VCL_TEMPLATE_FILE);
+        // first, check if a custom template is set
+        $customTemplate = $this->_getCustomTemplateFilename();
+        if ($customTemplate) { 
+            $tplFile = $customTemplate;
+        }
+        else { 
+            $tplFile = $this->_getVclTemplateFilename(self::VCL_TEMPLATE_FILE);
+        }
         $vcl = $this->_formatTemplate(file_get_contents($tplFile),
             $this->_getTemplateVars());
         return $doClean ? $this->_cleanVcl($vcl) : $vcl;

--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Version4.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Version4.php
@@ -31,7 +31,14 @@ class Nexcessnet_Turpentine_Model_Varnish_Configurator_Version4
      * @return string
      */
     public function generate($doClean = true) {
-        $tplFile = $this->_getVclTemplateFilename(self::VCL_TEMPLATE_FILE);
+        // first, check if a custom template is set
+        $customTemplate = $this->_getCustomTemplateFilename();
+        if ($customTemplate) { 
+            $tplFile = $customTemplate;
+        }
+        else { 
+            $tplFile = $this->_getVclTemplateFilename(self::VCL_TEMPLATE_FILE);
+        }
         $vcl = $this->_formatTemplate(file_get_contents($tplFile),
             $this->_getTemplateVars());
         return $doClean ? $this->_cleanVcl($vcl) : $vcl;

--- a/app/code/community/Nexcessnet/Turpentine/etc/config.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/config.xml
@@ -47,6 +47,7 @@
                 <server_list>127.0.0.1:6082</server_list>
                 <config_file>{{root_dir}}/var/default.vcl</config_file>
                 <custom_include_file>{{root_dir}}/app/code/community/Nexcessnet/Turpentine/misc/custom_include.vcl</custom_include_file>
+                <custom_vcl_template></custom_vcl_template>
             </servers>
         </turpentine_varnish>
         <turpentine_vcl>

--- a/app/code/community/Nexcessnet/Turpentine/etc/system.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/system.xml
@@ -82,6 +82,16 @@
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
                         </varnish_debug>
+                        <varnish_log_commands translate="label" module="turpentine">
+                            <label>Enable Varnish Command Logging</label>
+                            <comment>Log all commands sent to Varnish by Turpentine in the log specified (custom if enabled). Caution - can cause logs to grow quickly!</comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>turpentine/config_select_toggle</source_model>
+                            <sort_order>45</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </varnish_log_commands>
                         <block_debug translate="label" module="turpentine">
                             <label>Enable Block Logging</label>
                             <comment>Log block names for adding ESI, only enable when needed to avoid performance hit</comment>
@@ -92,6 +102,8 @@
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
                         </block_debug>
+
+
                         <ajax_messages translate="label" module="turpentine">
                             <label>Enable AJAX Flash Messages</label>
                             <comment>Enable fixing the messages block to load via AJAX, disable if you already have an extension that does this</comment>

--- a/app/code/community/Nexcessnet/Turpentine/etc/system.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/system.xml
@@ -242,6 +242,15 @@
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
                         </custom_include_file>
+			<custom_vcl_template>
+                            <label>Custom VCL Template</label>
+                            <frontend_type>text</frontend_type>
+                            <comment>If defined and present, this template will be used instead of the default VCL template appropriate for the version of Varnish.</comment>
+                            <sort_order>50</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store> 
+			</custom_vcl_template>
                     </fields>
                 </servers>
             </groups>


### PR DESCRIPTION
This adds the an option *Enable Varnish Command Logging* which if enabled will cause all commands sent to Varnish to be logged to the system.log - or the custom turpentine log file (if enabled).

This can cause logs to grow quickly, especially if the VCL is applied to varnish often!

Should solve https://github.com/nexcess/magento-turpentine/issues/1206