### PR TITLE
Adds and implements an option to log all commands sent to Varnish

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Admin/Socket.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Admin/Socket.php
@@ -499,6 +499,9 @@ class Nexcessnet_Turpentine_Model_Varnish_Admin_Socket {
                 "Got unexpected response code from Varnish: %d\n%s",
                 $response['code'], $response['text'] ));
         } else {
+            if (Mage::getStoreConfig('turpentine_varnish/general/varnish_log_commands')) { 
+                Mage::helper('turpentine/debug')->logDebug('VARNISH command sent: ' . $data);
+            }
             return $response;
         }
     }

--- a/app/code/community/Nexcessnet/Turpentine/etc/system.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/system.xml
@@ -82,6 +82,16 @@
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
                         </varnish_debug>
+                        <varnish_log_commands translate="label" module="turpentine">
+                            <label>Enable Varnish Command Logging</label>
+                            <comment>Log all commands sent to Varnish by Turpentine in the log specified (custom if enabled). Caution - can cause logs to grow quickly!</comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>turpentine/config_select_toggle</source_model>
+                            <sort_order>45</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </varnish_log_commands>
                         <block_debug translate="label" module="turpentine">
                             <label>Enable Block Logging</label>
                             <comment>Log block names for adding ESI, only enable when needed to avoid performance hit</comment>
@@ -92,6 +102,8 @@
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
                         </block_debug>
+
+
                         <ajax_messages translate="label" module="turpentine">
                             <label>Enable AJAX Flash Messages</label>
                             <comment>Enable fixing the messages block to load via AJAX, disable if you already have an extension that does this</comment>


### PR DESCRIPTION
This adds the an option Enable Varnish Command Logging which if enabled will cause all commands sent to Varnish to be logged to the system.log - or the custom turpentine log file (if enabled).

This can cause logs to grow quickly, especially if the VCL is applied to varnish often!

Should solve https://github.com/nexcess/magento-turpentine/issues/1206 - and replaces  PR https://github.com/nexcess/magento-turpentine/pull/1215 