### PR TITLE
Fix issues when switching back from 'Use VCL Fix'

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
@@ -110,8 +110,8 @@ abstract class Nexcessnet_Turpentine_Model_Varnish_Configurator_Abstract {
      * @return string
      */
     protected function _getVclTemplateFilename($baseFilename) {
-        $extensionDir = Mage::getModuleDir('', 'Nexcessnet_Turpentine');
-        return sprintf('%s/misc/%s', $extensionDir, $baseFilename);
+           $extensionDir = Mage::getModuleDir('', 'Nexcessnet_Turpentine');
+           return sprintf('%s/misc/%s', $extensionDir, $baseFilename);
     }
 
     /**
@@ -135,6 +135,23 @@ abstract class Nexcessnet_Turpentine_Model_Varnish_Configurator_Abstract {
             Mage::getStoreConfig('turpentine_varnish/servers/custom_include_file'),
             array('root_dir' => Mage::getBaseDir()) );
     }
+
+
+    /**
+     * Get the custom VCL template, if it exists
+     * Returns 'null' if the file doesn't exist
+     *
+     * @return string
+     */
+    protected function _getCustomTemplateFilename() {
+        $filePath = $this->_formatTemplate(
+            Mage::getStoreConfig('turpentine_varnish/servers/custom_vcl_template'),
+            array('root_dir' => Mage::getBaseDir())
+        );
+        if (is_file($filePath)) { return $filePath; }
+        else { return null; }
+    }
+
 
     /**
      * Format a template string, replacing {{keys}} with the appropriate values

--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
@@ -410,8 +410,8 @@ EOS;
      * @return string
      */
     protected function _getGenerateSessionStart() {
-        return Mage::getStoreConfig('turpentine_varnish/general/vcl_fix')
-            ? '/* -- REMOVED' : '';
+        if (Mage::getStoreConfig('turpentine_varnish/general/vcl_fix') == 1) { return ''; }
+        else { return '/* -- REMOVED'; }
     }
 
     /**
@@ -420,8 +420,8 @@ EOS;
      * @return string
      */
     protected function _getGenerateSessionEnd() {
-        return Mage::getStoreConfig('turpentine_varnish/general/vcl_fix')
-            ? '-- */' : '';
+        if (Mage::getStoreConfig('turpentine_varnish/general/vcl_fix') == 1) { return ''; }
+        else { return '-- */'; }
     }
 
 
@@ -431,8 +431,8 @@ EOS;
      * @return string
      */
     protected function _getGenerateSession() {
-        return Mage::getStoreConfigFlag('turpentine_varnish/general/vcl_fix')
-            ? 'return (pipe);' : 'call generate_session;';
+        if (Mage::getStoreConfig('turpentine_varnish/general/vcl_fix') == 1) { return 'call generate_session;'; }
+        else { return 'return (pipe);'; }
     }
 
 
@@ -442,8 +442,8 @@ EOS;
      * @return string
      */
     protected function _getGenerateSessionExpires() {
-        return Mage::getStoreConfig('turpentine_varnish/general/vcl_fix')
-            ? '# call generate_session_expires' : 'call generate_session_expires;';
+        if (Mage::getStoreConfig('turpentine_varnish/general/vcl_fix') == 1) { return 'call generate_session_expires;'; }
+        else { return ''; }
     }
 
     /**

--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Version3.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Version3.php
@@ -31,7 +31,14 @@ class Nexcessnet_Turpentine_Model_Varnish_Configurator_Version3
      * @return string
      */
     public function generate($doClean = true) {
-        $tplFile = $this->_getVclTemplateFilename(self::VCL_TEMPLATE_FILE);
+        // first, check if a custom template is set
+        $customTemplate = $this->_getCustomTemplateFilename();
+        if ($customTemplate) { 
+            $tplFile = $customTemplate;
+        }
+        else { 
+            $tplFile = $this->_getVclTemplateFilename(self::VCL_TEMPLATE_FILE);
+        }
         $vcl = $this->_formatTemplate(file_get_contents($tplFile),
             $this->_getTemplateVars());
         return $doClean ? $this->_cleanVcl($vcl) : $vcl;

--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Version4.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Version4.php
@@ -31,7 +31,14 @@ class Nexcessnet_Turpentine_Model_Varnish_Configurator_Version4
      * @return string
      */
     public function generate($doClean = true) {
-        $tplFile = $this->_getVclTemplateFilename(self::VCL_TEMPLATE_FILE);
+        // first, check if a custom template is set
+        $customTemplate = $this->_getCustomTemplateFilename();
+        if ($customTemplate) { 
+            $tplFile = $customTemplate;
+        }
+        else { 
+            $tplFile = $this->_getVclTemplateFilename(self::VCL_TEMPLATE_FILE);
+        }
         $vcl = $this->_formatTemplate(file_get_contents($tplFile),
             $this->_getTemplateVars());
         return $doClean ? $this->_cleanVcl($vcl) : $vcl;

--- a/app/code/community/Nexcessnet/Turpentine/etc/config.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/config.xml
@@ -47,6 +47,7 @@
                 <server_list>127.0.0.1:6082</server_list>
                 <config_file>{{root_dir}}/var/default.vcl</config_file>
                 <custom_include_file>{{root_dir}}/app/code/community/Nexcessnet/Turpentine/misc/custom_include.vcl</custom_include_file>
+                <custom_vcl_template></custom_vcl_template>
             </servers>
         </turpentine_varnish>
         <turpentine_vcl>

--- a/app/code/community/Nexcessnet/Turpentine/etc/system.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/system.xml
@@ -242,6 +242,15 @@
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
                         </custom_include_file>
+			<custom_vcl_template>
+                            <label>Custom VCL Template</label>
+                            <frontend_type>text</frontend_type>
+                            <comment>If defined and present, this template will be used instead of the default VCL template appropriate for the version of Varnish.</comment>
+                            <sort_order>50</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store> 
+			</custom_vcl_template>
                     </fields>
                 </servers>
             </groups>


### PR DESCRIPTION
After choosing the 'Use VCL fix' configuration option then switching back - the system would fail to remove the VCL changes made, causing it to essentially be "stuck" on the VCL fix option.