### PR TITLE
Condensed the UA "buckets" down to just "mobile" and "other" 

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
@@ -769,16 +769,6 @@ EOS;
         $tpl = <<<EOS
 if (req.http.User-Agent ~ "iP(?:hone|ad|od)|BlackBerry|Palm|Googlebot-Mobile|Mobile|mobile|mobi|Windows Mobile|Safari Mobile|Android|Opera (?:Mini|Mobi)") {
         set req.http.X-Normalized-User-Agent = "mobile";
-    } else if (req.http.User-Agent ~ "MSIE") {
-        set req.http.X-Normalized-User-Agent = "msie";
-    } else if (req.http.User-Agent ~ "Firefox") {
-        set req.http.X-Normalized-User-Agent = "firefox";
-    } else if (req.http.User-Agent ~ "Chrome") {
-        set req.http.X-Normalized-User-Agent = "chrome";
-    } else if (req.http.User-Agent ~ "Safari") {
-        set req.http.X-Normalized-User-Agent = "safari";
-    } else if (req.http.User-Agent ~ "Opera") {
-        set req.http.X-Normalized-User-Agent = "opera";
     } else {
         set req.http.X-Normalized-User-Agent = "other";
     }


### PR DESCRIPTION
To improve the cache rate, when User-Agent normalization is enabled - rather than using separate User-Agents for each browser, this simply tries to detect "mobile" and anything else is categorized as "other".