### PR TITLE
Add hash for persistent_shopping_cart cookie when hashing private blocks

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/misc/version-2.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-2.vcl
@@ -283,6 +283,11 @@ sub vcl_hash {
         {{advanced_session_validation}}
     }
 
+    if (req.http.X-Varnish-Esi-Access == "private" &&
+            req.http.Cookie ~ "persistent_shopping_cart=") {
+        set req.hash += regsub(req.http.Cookie, "^.*?persistent_shopping_cart=([^;]*);*.*$", "\1");
+    }
+
     if (req.http.X-Varnish-Esi-Access == "customer_group" &&
             req.http.Cookie ~ "customer_group=") {
         set req.hash += regsub(req.http.Cookie, "^.*?customer_group=([^;]*);*.*$", "\1");

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
@@ -272,6 +272,11 @@ sub vcl_hash {
 
     }
 
+    if (req.http.X-Varnish-Esi-Access == "private" &&
+            req.http.Cookie ~ "persistent_shopping_cart=") {
+        hash_data(regsub(req.http.Cookie, "^.*?persistent_shopping_cart=([^;]*);*.*$", "\1"));
+    }
+
     if (req.http.X-Varnish-Esi-Access == "customer_group" &&
             req.http.Cookie ~ "customer_group=") {
         hash_data(regsub(req.http.Cookie, "^.*?customer_group=([^;]*);*.*$", "\1"));

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
@@ -276,6 +276,11 @@ sub vcl_hash {
         {{advanced_session_validation}}
 
     }
+
+    if (req.http.X-Varnish-Esi-Access == "private" &&
+            req.http.Cookie ~ "persistent_shopping_cart=") {
+        hash_data(regsub(req.http.Cookie, "^.*?persistent_shopping_cart=([^;]*);*.*$", "\1"));
+    }
     return (lookup);
 }
 


### PR DESCRIPTION
This prevents the contents of private ESI blocks from being cached where there is no frontend cookie supplied with a request.

The persistent features allow the output of a customers name, or shopping cart contents within the header and it is possible for these to be seen by other users if this cookie is not included in the hash.

