### PR TITLE
Add hash for persistent_shopping_cart cookie when hashing private blocks

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/misc/version-2.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-2.vcl
@@ -283,6 +283,11 @@ sub vcl_hash {
         {{advanced_session_validation}}
     }
 
+    if (req.http.X-Varnish-Esi-Access == "private" &&
+            req.http.Cookie ~ "persistent_shopping_cart=") {
+        set req.hash += regsub(req.http.Cookie, "^.*?persistent_shopping_cart=([^;]*);*.*$", "\1");
+    }
+
     if (req.http.X-Varnish-Esi-Access == "customer_group" &&
             req.http.Cookie ~ "customer_group=") {
         set req.hash += regsub(req.http.Cookie, "^.*?customer_group=([^;]*);*.*$", "\1");

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
@@ -272,6 +272,11 @@ sub vcl_hash {
 
     }
 
+    if (req.http.X-Varnish-Esi-Access == "private" &&
+            req.http.Cookie ~ "persistent_shopping_cart=") {
+        hash_data(regsub(req.http.Cookie, "^.*?persistent_shopping_cart=([^;]*);*.*$", "\1"));
+    }
+
     if (req.http.X-Varnish-Esi-Access == "customer_group" &&
             req.http.Cookie ~ "customer_group=") {
         hash_data(regsub(req.http.Cookie, "^.*?customer_group=([^;]*);*.*$", "\1"));

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
@@ -276,6 +276,11 @@ sub vcl_hash {
         {{advanced_session_validation}}
 
     }
+
+    if (req.http.X-Varnish-Esi-Access == "private" &&
+            req.http.Cookie ~ "persistent_shopping_cart=") {
+        hash_data(regsub(req.http.Cookie, "^.*?persistent_shopping_cart=([^;]*);*.*$", "\1"));
+    }
     return (lookup);
 }
 


### PR DESCRIPTION
Re-opening #1228 to change target branch to devel. 
## 

This prevents the contents of private ESI blocks from being cached where there is no frontend cookie supplied with a request.

The persistent features allow the output of a customers name, or shopping cart contents within the header and it is possible for these to be seen by other users if this cookie is not included in the hash.

Example use cases:
1. Administrator sets "VCL Fix" configuration to "Yes". Administrator clicks on "Flush Cache" button. First request to Magento is for a user with an expired frontend cookie and user has a persistent shopping cart / login. ESI request for header contains customer's name and the header is hashed without a frontend cookie. 
2. Administrator sets "VCL Fix" configuration to "No". Cache is flushed or private block (header) expires, first user to visit site has "persistent_shopping_cart" cookie and no pre-existing frontend cookie. Header contains customer's name, is not hashed with a "frontend" cookie. Customer's name / cart is shown to all users without a frontend cookie.
## 

The first instance happens very rarely but enough that we have had to patch this on 2 production instances. The second appears more common and easily repeatable.

This fix works on the following basis:
1. The persistent_shopping_cart cookie is independent of the frontend cookie 
2. Both cookies can be used to output personal information about the user
3. There may not always be a frontend cookie when performing hash
4. Changes in the value of the persistent_shopping_cart cookie should result in different content being displayed in private blocks 
