### PR TITLE
Adds better logging of hash_data calls in vcl_hash

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
@@ -234,48 +234,65 @@ sub vcl_pipe {
 # }
 
 sub vcl_hash {
+    std.log("vcl_hash start");
+
     # For static files we keep the hash simple and don't add the domain.
     # This saves memory when a static file is used on multiple domains.
     if ({{simple_hash_static}} && req.http.X-Varnish-Static) {
+        std.log("hash_data static file - req.url: " + req.url);
         hash_data(req.url);
         if (req.http.Accept-Encoding) {
             # make sure we give back the right encoding
+            std.log("hash_data static file - Accept-Encoding: " + req.http.Accept-Encoding);
             hash_data(req.http.Accept-Encoding);
         }
+        std.log("vcl_hash end return lookup");
         return (lookup);
     }
 
+
     if({{send_unmodified_url}} && req.http.X-Varnish-Cache-Url) {
         hash_data(req.http.X-Varnish-Cache-Url);
+        std.log("hash_data - X-Varnish-Cache-Url: " + req.http.X-Varnish-Cache-Url);
     } else {
         hash_data(req.url);
+        std.log("hash_data - req.url: " + req.url );
     }
 
     if (req.http.Host) {
         hash_data(req.http.Host);
+        std.log("hash_data - req.http.Host: " + req.http.Host);
     } else {
         hash_data(server.ip);
     }
+
+    std.log("hash_data - req.http.Ssl-Offloaded: " + req.http.Ssl-Offloaded);
     hash_data(req.http.Ssl-Offloaded);
+
     if (req.http.X-Normalized-User-Agent) {
         hash_data(req.http.X-Normalized-User-Agent);
+        std.log("hash_data - req.http.X-Normalized-User-Agent: " + req.http.X-Normalized-User-Agent);
     }
     if (req.http.Accept-Encoding) {
         # make sure we give back the right encoding
         hash_data(req.http.Accept-Encoding);
+        std.log("hash_data - req.http.Accept-Encoding: " + req.http.Accept-Encoding);
     }
     if (req.http.X-Varnish-Store || req.http.X-Varnish-Currency) {
         # make sure data is for the right store and currency based on the *store*
         # and *currency* cookies
         hash_data("s=" + req.http.X-Varnish-Store + "&c=" + req.http.X-Varnish-Currency);
+        std.log("hash_data - Store and Currency: " + "s=" + req.http.X-Varnish-Store + "&c=" + req.http.X-Varnish-Currency);
     }
 
     if (req.http.X-Varnish-Esi-Access == "private" &&
             req.http.Cookie ~ "frontend=") {
+        std.log("hash_data - frontned cookie: " + regsub(req.http.Cookie, "^.*?frontend=([^;]*);*.*$", "\1"));
         hash_data(regsub(req.http.Cookie, "^.*?frontend=([^;]*);*.*$", "\1"));
         {{advanced_session_validation}}
 
     }
+    std.log("vcl_hash end return lookup");
     return (lookup);
 }
 


### PR DESCRIPTION
This adds substantially more information the varnishlog in Varnish 4. Before, there was no logging of calls to `hash_data` (at least in Varnish 4.0.3) which made it more difficult to debug issues with cache misses. This adds the item being added to the hash as well as its value.

