### PR TITLE
Fixed Host normalization for certain cases + support X-Forwarded-Host

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Config/Select/NormalizeHost.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Config/Select/NormalizeHost.php
@@ -1,0 +1,34 @@
+<?php
+
+/** 
+ * Nexcess.net Turpentine Extension for Magento
+ * Copyright (C) 2012  Nexcess.net L.L.C.
+ * 
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */ 
+
+class Nexcessnet_Turpentine_Model_Config_Select_NormalizeHost {
+    /**
+     * @return array
+     */
+    public function toOptionArray() {
+        $helper = Mage::helper('turpentine');
+        return array(
+            array('value'=>'yes', 'label'=>Mage::helper('adminhtml')->__('Enable')),
+            array('value'=>'yes_forwarded_host', 'label'=>$helper->__('Yes, use HTTP X-Forwarded-Host Header')),
+            array('value'=>'no', 'label'=>Mage::helper('adminhtml')->__('Disable')),
+        );
+    }
+}

--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
@@ -824,6 +824,21 @@ EOS;
     }
 
     /**
+     * Get the Host normalization sub routine
+     *
+     * @return string
+     */
+    protected function _vcl_sub_normalize_host_forwarded() {
+        $tpl = <<<EOS
+if (req.http.X-Forwarded-Host)
+{
+    set req.http.Host = req.http.X-Forwarded-Host;
+}
+EOS;
+        return $this->_formatTemplate($tpl, array());
+    }
+
+    /**
      * Get the hostname for cookie normalization
      *
      * @return string
@@ -990,8 +1005,13 @@ EOS;
         if (Mage::getStoreConfig('turpentine_vcl/normalization/user_agent')) {
             $vars['normalize_user_agent'] = $this->_vcl_sub_normalize_user_agent();
         }
-        if (Mage::getStoreConfig('turpentine_vcl/normalization/host')) {
-            $vars['normalize_host'] = $this->_vcl_sub_normalize_host();
+        Mage::log(Mage::getStoreConfig('turpentine_vcl/normalization/host'));
+        if (Mage::getStoreConfig('turpentine_vcl/normalization/host') && Mage::getStoreConfig('turpentine_vcl/normalization/host') != 'no') {
+            if (Mage::getStoreConfig('turpentine_vcl/normalization/host') == "yes_forwarded_host") {
+                $vars['normalize_host'] = $this->_vcl_sub_normalize_host_forwarded();
+            } else {
+                $vars['normalize_host'] = $this->_vcl_sub_normalize_host();
+            }
         }
         if (Mage::getStoreConfig('turpentine_vcl/normalization/cookie_regex')) {
             $vars['normalize_cookie_regex'] = $this->_getNormalizeCookieRegex();

--- a/app/code/community/Nexcessnet/Turpentine/etc/system.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/system.xml
@@ -413,7 +413,7 @@
                             <label>Normalize Host</label>
                             <comment>Force requests to be for a specific domain name, will probably break most multi-store setups</comment>
                             <frontend_type>select</frontend_type>
-                            <source_model>turpentine/config_select_toggle</source_model>
+                            <source_model>turpentine/config_select_normalizeHost</source_model>
                             <sort_order>30</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
@@ -424,7 +424,7 @@
                             <comment>Domain to force requests to, defaults to the domain in the base URL</comment>
                             <frontend_type>text</frontend_type>
                             <depends>
-                                <host>1</host>
+                                <host>yes</host>
                             </depends>
                             <sort_order>40</sort_order>
                             <show_in_default>1</show_in_default>

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
@@ -110,6 +110,8 @@ sub vcl_recv {
         }
     }
 
+    {{normalize_host}}
+
     # We only deal with GET and HEAD by default
     # we test this here instead of inside the url base regex section
     # so we can disable caching for the entire site if needed
@@ -129,7 +131,6 @@ sub vcl_recv {
 
     {{normalize_encoding}}
     {{normalize_user_agent}}
-    {{normalize_host}}
 
     # check if the request is for part of magento
     if (req.url ~ "{{url_base_regex}}") {


### PR DESCRIPTION
See https://github.com/nexcess/magento-turpentine/pull/1237

In detail this PR contains two changes:

1) BUGFIX: As the current VCL for Varnish 4.x contains {{normalize_host}} just after the first cases requests might get handled (see https://github.com/nexcess/magento-turpentine/blob/devel/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl#L124) there are cases in which the Host normalization just does not happen. In this case the backend server will get an invalid Host header and such fail to handle the request. As visible in the VCL (https://github.com/nexcess/magento-turpentine/blob/devel/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl#L121) this is true for all requests using authentication and when caching is disabled.

To fix this issue I moved {{normalize_host}} before if-statement passing unnormalized requests to the backend server.

2) FEATURE: We currently use Varnish behind an Apache server, but I think the following is true for other frontend proxies as well: The frontend proxy sitting before Varnish might set an additional HTTP header to allow Varnish to use that information for Host detection. This allows us to normalize the Host header based on the original value of it and thus allows us to normalize Host headers for multisite setups. The PR makes the necessary changes to allow such an setup.

In detail:

The reason you need Host normalization:
Frontend-Server (Host=www.domain.com) -> passes request to Varnish on localhost:1234 and sets the Host header accordingly
Varnish (Host=localhost:1234) will now pass the wrong Host header to its backend server -> The backend server will not be able to select the right domain configuration in this case (no Vhost for localhost)

What current normalization does is just ignoring the Host header inside Varnish and just using what is configured in the backend. This way you loose the possibility to have multisite setups, as the Host header will always be "www.domain.com", no matter what.

Now the frontend server may preserve the original Host in some HTTP header, as Apache does. This means:
Frontend-Server (Host=www.domain.com) -> Varnish (Host=localhost:1234, X-Forwarded-Host=www.domain.com) -> Backend Server (Host=…)

Now using X-Forwarded-Host for the backend server Host header will just fix the Host-header problems as fixation does. In addition it allows for multisite setups.

Hope this clarifies things. ;-)
