### PR TITLE
Adds more flexibility/options to warm-cache.sh

### DIFF
--- a/util/warm-cache.sh
+++ b/util/warm-cache.sh
@@ -17,49 +17,77 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-SITEMAP_URL="$1"
-TMP_URL_FILE="/tmp/urls_$(cat /proc/sys/kernel/random/uuid).txt"
-PROCS="${PROCS-$(grep processor /proc/cpuinfo | wc -l)}"
 
-echo '<root/>' | xpath -e '*' &>/dev/null
+show_help()
+{	
+	echo "Warm the Varnish page cache by using siege to hit a list of URLs."
+	echo "Options:"
+	echo "-u	URL source - either the URL of a magento sitemap xml file, or the path to a file containing URLS - one per line"
+	echo "-a	User-Agent to use"
+	echo "-c	Number of concurrent \"users\" - siege will hit this many urls at once. Higher numbers = more server load."
 
-if [ $? -eq 2 ]; then
-    XPATH_BIN='xpath'
-else
-    XPATH_BIN='xpath -e'
+}
+
+# set defaults
+CONC=3 # default concurrency level
+TMP_URL_FILE="./urls_$RANDOM.txt" # location to store temporarily URL file
+REMOVE_TMP_FILE=1
+
+if [ $# -lt 1 ]; then
+	show_help
+	exit 1
 fi
 
-if [ -z "$SITEMAP_URL" ]; then
-    cat <<EOF
-Usage: $0 <sitemap URL>
+while getopts :u:a:c: opt
+do 
+	case "$opt" in 
+	u) URLS="$OPTARG";;
+	a) AGENT="$OPTARG";;
+	c) CONC="$OPTARG";;
+	\?) show_help;;
+	esac
+done
 
-    Warm Magento's cache by visiting the URLs in Magento's sitemap
 
-    Example:
-        $0 http://example.com/magento/sitemap.xml
-EOF
+# process URLS as needed
+if [[ $URLS =~ ^http ]]; then #fetch URLs from sitemap URL
+	
+	echo '<root/>' | xpath -e '*' &>/dev/null
 
-    exit 1
-fi
+	if [ $? -eq 2 ]; then
+	    XPATH_BIN='xpath'
+	else
+	    XPATH_BIN='xpath -e'
+	fi
 
-echo "Getting URLs from sitemap..."
+	echo "Getting URLs from sitemap..."
 
-curl -ks "$SITEMAP_URL" | \
-	$XPATH_BIN '/urlset/url/loc/text()' 2>/dev/null | \
+	curl -ks "$URLS" | \
+		$XPATH_BIN '/urlset/url/loc/text()' 2>/dev/null | \
 	sed -r 's~http(s)?:~\nhttp\1:~g' | \
-    grep -vE '^\s*$' > "$TMP_URL_FILE"
+	grep -vE '^\s*$' > "$TMP_URL_FILE"
+else
+	TMP_URL_FILE=$URLS
+	REMOVE_TMP_FILE=0
+	if [ -f $TMP_URL_FILE ]; then
+		echo "Getting URLs from $TMP_URL_FILE..."
+	else 
+		echo "No URL file found at $TMP_URL_FILE"
+		exit 1
+	fi
+fi
 
-echo "Warming $(cat $TMP_URL_FILE | wc -l) URLs using $PROCS processes..."
+UA=""
+if [[ $AGENT =~ .. ]]; then 
+	UA="-A '$AGENT'"
+	echo "Warning with User-Agent '$AGENT'"
+fi
 
-cat "$TMP_URL_FILE" | \
-    xargs -P "$PROCS" -r -n 1 -- \
-        siege -b -v -c 1 -r once 2>/dev/null | \
-    sed -r 's/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g' | \
-    grep -E '^HTTP'
-cat "$TMP_URL_FILE" | \
-    xargs -P "$PROCS" -r -n 1 -- \
-        siege -H 'Accept-Encoding: gzip' -b -v -c 1 -r once 2>/dev/null | \
-    sed -r 's/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g' | \
-    grep -E '^HTTP'
+echo "Warming $(cat $TMP_URL_FILE | wc -l) URLs using $CONC concurrent users..."
+siege -b -v -c $CONC -f $TMP_URL_FILE -r once $UA -H 'Accept-Encoding: gzip' 2>/dev/null 
 
-rm -f "$TMP_URL_FILE"
+if [ $REMOVE_TMP_FILE == 1 ]; then 
+	rm -f "$TMP_URL_FILE"
+fi
+
+exit 0


### PR DESCRIPTION
The script has been changed to be more flexible

- Can set the User-Agent to whatever you like (-a)
- Can dynamically pull URLs from a sitemap, or use a static URL file (-u)
- Can set the number of concurrent "users" to use when warming the cache - the list of URLs will be split between the available "users"