### PR TITLE
Fix issue with customer name not being removed from header when clearing persistent cookie

### DIFF
--- a/app/design/frontend/base/default/layout/turpentine_esi.xml
+++ b/app/design/frontend/base/default/layout/turpentine_esi.xml
@@ -44,7 +44,8 @@
                         <wishlist_item_save_after/>
                         <wishlist_item_delete_after/>
                         <sales_quote_save_after/>
-			<controller_action_layout_render_before_catalogsearch_result_index />
+                        <controller_action_layout_render_before_catalogsearch_result_index />
+                        <persistent_session_expired/>
                     </flush_events>
                 </params>
             </action>


### PR DESCRIPTION
The default Magento "Remember Me" functionality provides a "Not <name>?" link in the header to allow a customer to clear the persistent cookie on return to Magento (after default session expiration).

Clicking this link with Turpentine enabled doesn't currently cause the header to be purged.

This fix adds the "persistent_session_expired" event to the default header's flush_events. This event is dispatched by Mage_Persistent_IndexController::_cleanup() after the user clicks on the "Not <name>?" link.