### PR TITLE
Fixed Crawler UserAgent regexp to match newer Siege versions.

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/etc/config.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/config.xml
@@ -62,7 +62,7 @@
                 <frontend_timeout>300</frontend_timeout>
                 <admin_timeout>21600</admin_timeout>
                 <crawlers>127.0.0.1</crawlers>
-                <crawler_user_agents><![CDATA[ApacheBench/.*,.*Googlebot.*,JoeDog/.*Siege.*,magespeedtest\.com,Nexcessnet_Turpentine/.*,.*PTST.*]]></crawler_user_agents>
+                <crawler_user_agents><![CDATA[ApacheBench/.*,.*Googlebot.*,JoeDog/.*,.*Siege/.*,magespeedtest\.com,Nexcessnet_Turpentine/.*,.*PTST.*]]></crawler_user_agents>
             </backend>
             <normalization>
                 <encoding>1</encoding>


### PR DESCRIPTION
A small change with big impact on performance tests using newer versions of Siege.
The previous Crawler UserAgent regular expression does not match newer versions of Siege. This resulted in all Siege requests being passed to the PHP backend server, because Siege has no session.

I tested all listed UserAgents, these do all match the new regexp:

    JoeDog/1.00 [en] (X11; I; Siege 2.59)
    Mozilla/5.0 (pc-x86_64-linux-gnu) Siege/3.0.8
    Mozilla/5.0 (unknown-x86_64-linux-gnu) Siege/4.0.0-beta5
    ApacheBench/2.3
    Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
    magespeedtest.com
    Nexcessnet_Turpentine/0.6.8 Magento/1.9.0.1 Varien_Http_Client
    Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0; PTST 2.295)

Fix for existing installs using N98-Magerun:

    n98-magerun.phar config:set "turpentine_vcl/backend/crawler_user_agents" "ApacheBench/.*,.*Googlebot.*,JoeDog/.*,.*Siege/.*,magespeedtest\.com,Nexcessnet_Turpentine/.*,.*PTST.*"
    n98-magerun.phar cache:clean config
    ## In Magento Admin: System > Cache Management > Apply Varnish Config

