### PR TITLE
Bugfix in "Normalize Encoding" for visitors who accept "*"

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
@@ -806,7 +806,7 @@ EOS;
     protected function _vcl_sub_normalize_encoding() {
         $tpl = <<<EOS
 if (req.http.Accept-Encoding) {
-        if (req.http.Accept-Encoding ~ "gzip") {
+        if (req.http.Accept-Encoding ~ "\*|gzip") {
             set req.http.Accept-Encoding = "gzip";
         } else if (req.http.Accept-Encoding ~ "deflate") {
             set req.http.Accept-Encoding = "deflate";


### PR DESCRIPTION
Bugfix in "Normalize Encoding": When a visitor accepts `*` this means it also accepts `gzip`.
This is a performance fix for newer versions of Siege. They use `Accept-Encoding: *`
Often caches are warmed for `Accept-Encoding: gzip` because all modern browsers do accept Gzip.