### PR TITLE
Added one more format for configuration regexp

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Admin/Socket.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Admin/Socket.php
@@ -412,7 +412,7 @@ class Nexcessnet_Turpentine_Model_Varnish_Admin_Socket {
             if (preg_match($regexp, $cliBufferResponse['text'], $match)) {
                 $realLimit = (int) $match[1];
                 if (isset($match[2])) {
-                    $factors = array('k'=>1, 'm'=>2, 'g'=>3);
+                    $factors = array('b'=>0, 'k'=>1, 'm'=>2, 'g'=>3);
                     $realLimit *= pow(1024, $factors[$match[2]]);
                 }
             } else {

--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Admin/Socket.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Admin/Socket.php
@@ -407,7 +407,7 @@ class Nexcessnet_Turpentine_Model_Varnish_Admin_Socket {
             $regexp = '~^cli_buffer\s+(\d+)\s+\[bytes\]~';
             if ($this->getVersion() === '4.0') {
                 // Varnish4 supports "16k" style notation
-                $regexp = '~^cli_buffer\s+Value is:\s+(\d+)([k|m|g]{1})?\s+\[bytes\]~';
+                $regexp = '~^cli_buffer\s+Value is:\s+(\d+)([k|m|g|b]{1})?\s+\[bytes\]~';
             }
             if (preg_match($regexp, $cliBufferResponse['text'], $match)) {
                 $realLimit = (int) $match[1];


### PR DESCRIPTION
Hi, small change to regular expression because extension can't determine correct buffer size on CentoOS 7 and varnish-4.0.3 revision b8c4a34

Some how it shows value in incorrect format, in bytes instead of kilobytes or what ever.
```
varnishadm param.show | grep cli_buffer
cli_buffer                 240000b [bytes]
```
