### PR TITLE
Fix the issue when redirect HTTP to HTTPS

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
@@ -888,6 +888,24 @@ EOS;
     }
 
     /**
+     * When using Varnish as front door listen on port 80 and Nginx/Apache listen on port 443 for HTTPS, the fix will keep the url parameters when redirect from HTTP to HTTPS.
+     *
+     * @return string
+     */
+    protected function _vcl_sub_https_redirect_fix() {
+        $baseUrl = Mage::getBaseUrl(Mage_Core_Model_Store::URL_TYPE_WEB);
+        $baseUrl = str_replace(array('http://','https://'), '', $baseUrl);
+        $baseUrl = rtrim($baseUrl,'/');
+        
+        $tpl = <<<EOS
+if ( (req.http.host ~ "^(?i)www.$baseUrl" || req.http.host ~ "^(?i)$baseUrl") && req.http.X-Forwarded-Proto !~ "(?i)https") {
+        return (synth(750, ""));
+    }
+EOS;
+        return $tpl;
+    }
+
+    /**
      * Get the allowed IPs when in maintenance mode
      *
      * @return string
@@ -1005,6 +1023,10 @@ EOS;
             $vars['maintenance_allowed_ips'] = $this->_vcl_sub_maintenance_allowed_ips();
             // set the vcl_error from Magento database
             $vars['vcl_synth'] = $this->_vcl_sub_synth();
+        }
+        
+        if (Mage::getStoreConfig('turpentine_varnish/general/https_redirect_fix')) {
+            $vars['https_redirect'] = $this->_vcl_sub_https_redirect_fix();
         }
 
         $customIncludeFile = $this->_getCustomIncludeFilename();

--- a/app/code/community/Nexcessnet/Turpentine/etc/system.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/system.xml
@@ -66,12 +66,22 @@
                             <label>Use VCL fix</label>
                             <comment>When Enable is selected, a VCL fix will be used to prevent formKey issues. If Disable is selected, an observer will be used.</comment>
                             <frontend_type>select</frontend_type>
-                            <sort_order>28</sort_order>
+                            <sort_order>26</sort_order>
                             <source_model>adminhtml/system_config_source_enabledisable</source_model>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </vcl_fix>
+                        <https_redirect_fix translate="label comment">
+                            <label>Fix HTTPS redirect</label>
+                            <comment>When using Varnish as front door listen on port 80 and Nginx/Apache listen on port 443 for HTTPS, the fix will keep the url parameters when redirect from HTTP to HTTPS.</comment>
+                            <frontend_type>select</frontend_type>
+                            <sort_order>28</sort_order>
+                            <source_model>adminhtml/system_config_source_enabledisable</source_model>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </https_redirect_fix>
                         <varnish_debug translate="label" module="turpentine">
                             <label>Enable Debug Info</label>
                             <comment>It is a major security vulnerability, to leave this enabled on production sites</comment>

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
@@ -92,8 +92,18 @@ sub generate_session_expires {
 {{generate_session_end}}
 ## Varnish Subroutines
 
+sub vcl_synth {
+    if (resp.status == 750) {
+        set resp.status = 301;
+        set resp.http.Location = "https://" + req.http.host + req.url;
+        return(deliver);
+    }
+}
+
 sub vcl_recv {
 	{{maintenance_allowed_ips}}
+
+    {{https_redirect}}
 
     # this always needs to be done so it's up at the top
     if (req.restarts == 0) {

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
@@ -97,8 +97,18 @@ sub generate_session_expires {
 {{generate_session_end}}
 ## Varnish Subroutines
 
+sub vcl_synth {
+    if (resp.status == 750) {
+        set resp.status = 301;
+        set resp.http.Location = "https://" + req.http.host + req.url;
+        return(deliver);
+    }
+}
+
 sub vcl_recv {
 	{{maintenance_allowed_ips}}
+
+    {{https_redirect}}
 
     # this always needs to be done so it's up at the top
     if (req.restarts == 0) {


### PR DESCRIPTION
I am using Varnish as front door listen on public IP & port 80, and using NGINX listen on port 80 for the backend, and 443 for HTTPS.

The issue is when I enter the HTTP URL with parameters it always redirects to home page. For example,  I enter http://example.com/about-us , it redirects to https://example.com 

The fix will keep the URL parameters when redirecting from HTTP to HTTPS. So when I enter http://example.com/about-us, it will redirect to https://example.com/about-us

Thanks to considering to check and merge.