### PR TITLE
Fix for picking the wrong block from the layout when multiple blocks found

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/controllers/EsiController.php
+++ b/app/code/community/Nexcessnet/Turpentine/controllers/EsiController.php
@@ -212,9 +212,17 @@ class Nexcessnet_Turpentine_EsiController extends Mage_Core_Controller_Front_Act
         $turpentineHelper = Mage::helper('turpentine/data')
             ->setLayout($layout);
 
-        $blockNode = current($layout->getNode()->xpath(
-                sprintf('//block[@name=\'%s\']', $esiData->getNameInLayout())
+        $blockNodes = $layout->getNode()->xpath(
+            sprintf('//block[@name=\'%s\']', $esiData->getNameInLayout())
+        );
+        $blockNode = current($blockNodes);
+        if (1 < count($blockNodes)) {
+            // there appear to be multiple blocks with the requested name, use extra criteria
+            $blockNode = current($layout->getNode()->xpath(
+                sprintf('//block[@name=\'%s\'][action[@method=\'setEsiOptions\']]',
+                    $esiData->getNameInLayout())
             ));
+        }
 
         if ( ! ($blockNode instanceof Mage_Core_Model_Layout_Element)) {
             Mage::helper('turpentine/debug')->logWarn(


### PR DESCRIPTION
Some themes like Ultimo use `unsetChild` to remove default Magento blocks, and create the block again with the same name but other properties in another place.
The `unsetChild` action does not remove a block from the XML, only from the object structure.
When an ESI block is requested, the controller was only looking for the name of the block in the layout XML, so in some cases it picks the removed block.
In the case when multiple blocks are found with the same name, I added a check for `setEsiOptions` inside the block XML.