### PR TITLE
Fix for picking the wrong block from the layout when multiple blocks found - v2

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Helper/Esi.php
+++ b/app/code/community/Nexcessnet/Turpentine/Helper/Esi.php
@@ -363,6 +363,32 @@ class Nexcessnet_Turpentine_Helper_Esi extends Mage_Core_Helper_Abstract {
     }
 
     /**
+     * Grab a block node by name from the layout XML.
+     *
+     * Multiple blocks with the same name may exist in the layout, because some themes
+     * use 'unsetChild' to remove a block and create it with the same name somewhere
+     * else. For example Ultimo does this.
+     *
+     * @param Mage_Core_Model_Layout $layout
+     * @param string $blockName value of name= attribute in layout XML
+     * @return Mage_Core_Model_Layout_Element
+     */
+    public function getEsiLayoutBlockNode($layout,$blockName) {
+        // first try very specific by checking for action setEsiOptions inside block
+        $blockNode = current($layout->getNode()->xpath(
+            sprintf('//block[@name=\'%s\'][action[@method=\'setEsiOptions\']]',
+                $blockName)
+        ));
+        // fallback: only match name
+        if ( ! ($blockNode instanceof Mage_Core_Model_Layout_Element)) {
+            $blockNode = current($layout->getNode()->xpath(
+                sprintf('//block[@name=\'%s\']', $blockName)
+            ));
+        }
+        return $blockNode;
+    }
+
+    /**
      * Load the ESI cache clear events from the layout
      *
      * @return array

--- a/app/code/community/Nexcessnet/Turpentine/Model/Observer/Esi.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Observer/Esi.php
@@ -415,9 +415,8 @@ class Nexcessnet_Turpentine_Model_Observer_Esi extends Varien_Event_Observer {
         $activeHandles = array();
         // get the xml node representing the block we're working on (from the
         // default handle probably)
-        $blockNode = current($layout->getNode()->xpath(sprintf(
-            '//block[@name=\'%s\']',
-            $block->getNameInLayout() )));
+        $blockNode = Mage::helper('turpentine/esi')->getEsiLayoutBlockNode(
+            $layout, $block->getNameInLayout());
         $childBlocks = Mage::helper('turpentine/data')
             ->getChildBlockNames($blockNode);
         foreach ($childBlocks as $blockName) {

--- a/app/code/community/Nexcessnet/Turpentine/controllers/EsiController.php
+++ b/app/code/community/Nexcessnet/Turpentine/controllers/EsiController.php
@@ -212,10 +212,8 @@ class Nexcessnet_Turpentine_EsiController extends Mage_Core_Controller_Front_Act
         $turpentineHelper = Mage::helper('turpentine/data')
             ->setLayout($layout);
 
-        $blockNode = current($layout->getNode()->xpath(
-                sprintf('//block[@name=\'%s\']', $esiData->getNameInLayout())
-            ));
-
+        $blockNode = Mage::helper('turpentine/esi')->getEsiLayoutBlockNode(
+            $layout, $esiData->getNameInLayout());
         if ( ! ($blockNode instanceof Mage_Core_Model_Layout_Element)) {
             Mage::helper('turpentine/debug')->logWarn(
                             'No block node found with @name="%s"',


### PR DESCRIPTION
Some themes like Ultimo use `unsetChild` to remove default Magento blocks, and create the block again with the same name but other properties in another place.
The `unsetChild` action does not remove a block from the XML, only from the object structure.
When an ESI block is requested, the controller was only looking for the name of the block in the layout XML, so in some cases it picked the removed block.
I added a check for the `setEsiOptions` action inside the block XML, with a fallback to the old behaviour.
