### PR TITLE
Keep params from original url

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Observer/Esi.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Observer/Esi.php
@@ -297,6 +297,11 @@ class Nexcessnet_Turpentine_Model_Observer_Esi extends Varien_Event_Observer {
                 );
             }
 
+            /**
+             * Keep params from original url
+             */
+            $urlOptions['_query'] = Mage::app()->getRequest()->getParams();
+            
             $esiUrl = Mage::getUrl('turpentine/esi/getBlock', $urlOptions);
             if ($esiOptions[$methodParam] == 'esi') {
                 // setting [web/unsecure/base_url] can be https://... but ESI can never be HTTPS


### PR DESCRIPTION
I had problem with custom **$_GET** params, the ESI Observer set ESI url and remove all my custom params.

This PR will get params form origin URL and add `_query` to  `$urlOptions` so the ESI url will contains all params from the origin url

```
$urlOptions['_query'] = Mage::app()->getRequest()->getParams();
```