### PR TITLE
Custom cookie hash

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
@@ -150,7 +150,9 @@ abstract class Nexcessnet_Turpentine_Model_Varnish_Configurator_Abstract {
             $tpl = '';
             $keys = Mage::helper('turpentine/data')->cleanExplode(PHP_EOL, $keys);
             foreach($keys as $key){
+                $tpl .= 'if (req.http.Cookie ~ "'.$key.'=") {'.PHP_EOL;
                 $tpl .= 'hash_data(regsub(req.http.Cookie, "^.*?'.$key.'=([^;]*);*.*$", "\1"));'.PHP_EOL;
+                $tpl .= '}'.PHP_EOL;
             }
             return $tpl;
         }

--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
@@ -140,6 +140,22 @@ abstract class Nexcessnet_Turpentine_Model_Varnish_Configurator_Abstract {
 
 
     /**
+     * Get custom cookie keys and add to varnish hash
+     *
+     * @return string
+     */
+    protected function _getCustomCookieHash() {
+        $keys = Mage::getStoreConfig('turpentine_vcl/cookie/keys');
+        if(!empty($keys)){
+            $keys = implode('|',Mage::helper('turpentine/data')->cleanExplode(PHP_EOL, $keys));
+            
+            return 'hash_data(regsub(req.http.Cookie, "^.*?('.$keys.')=([^;]*);*.*$", "\1"));';
+        }
+        return null;
+    }
+
+
+    /**
      * Get the custom VCL template, if it exists
      * Returns 'null' if the file doesn't exist
      *
@@ -1009,6 +1025,7 @@ EOS;
                 $this->_getVclTemplateFilename(self::VCL_CUSTOM_C_CODE_FILE) ),
             'esi_private_ttl'   => Mage::helper('turpentine/esi')
                 ->getDefaultEsiTtl(),
+            'custom_cookie_hash'    => $this->_getCustomCookieHash(),
         );
 
         if ((bool) Mage::getStoreConfig('turpentine_vcl/urls/bypass_cache_store_url')) {

--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
@@ -147,9 +147,12 @@ abstract class Nexcessnet_Turpentine_Model_Varnish_Configurator_Abstract {
     protected function _getCustomCookieHash() {
         $keys = Mage::getStoreConfig('turpentine_vcl/cookie/keys');
         if(!empty($keys)){
-            $keys = implode('|',Mage::helper('turpentine/data')->cleanExplode(PHP_EOL, $keys));
-            
-            return 'hash_data(regsub(req.http.Cookie, "^.*?('.$keys.')=([^;]*);*.*$", "\1"));';
+            $tpl = '';
+            $keys = Mage::helper('turpentine/data')->cleanExplode(PHP_EOL, $keys);
+            foreach($keys as $key){
+                $tpl .= 'hash_data(regsub(req.http.Cookie, "^.*?'.$key.'=([^;]*);*.*$", "\1"));'.PHP_EOL;
+            }
+            return $tpl;
         }
         return null;
     }

--- a/app/code/community/Nexcessnet/Turpentine/etc/system.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/system.xml
@@ -579,6 +579,25 @@
                         </bypass_cache_store_url>
                     </fields>
                 </urls>
+                <cookie translate="label" module="turpentine">
+                    <label>Cookie-based Caching</label>
+                    <frontend_type>text</frontend_type>
+                    <sort_order>35</sort_order>
+                    <show_in_default>1</show_in_default>
+                    <show_in_website>0</show_in_website>
+                    <show_in_store>0</show_in_store>
+                    <fields>
+                        <keys translate="label" module="turpentine">
+                            <label>Cookie Keys</label>
+                            <frontend_type>textarea</frontend_type>
+                            <comment>List of cookie keys to include in caching hash key.</comment>
+                            <sort_order>10</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </keys>
+                    </fields>
+                </cookie>
                 <params translate="label" module="turpentine">
                     <label>Parameter-based Caching</label>
                     <frontend_type>text</frontend_type>

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-2.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-2.vcl
@@ -288,6 +288,8 @@ sub vcl_hash {
         set req.hash += regsub(req.http.Cookie, "^.*?customer_group=([^;]*);*.*$", "\1");
     }
 
+    {{custom_cookie_hash}}
+
     return (hash);
 }
 

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
@@ -291,6 +291,8 @@ sub vcl_hash {
         hash_data(regsub(req.http.Cookie, "^.*?customer_group=([^;]*);*.*$", "\1"));
     }
     
+    {{custom_cookie_hash}}
+    
     return (hash);
 }
 

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
@@ -318,6 +318,9 @@ sub vcl_hash {
             req.http.Cookie ~ "customer_group=") {
         hash_data(regsub(req.http.Cookie, "^.*?customer_group=([^;]*);*.*$", "\1"));
     }
+
+    {{custom_cookie_hash}}
+
     std.log("vcl_hash end return lookup");
     return (lookup);
 }


### PR DESCRIPTION
Hi,

I had problem when using specific cookie to check and change the magento design package.

When people visit my site using a mobile device they will see a link "View desktop version", when they click that link I set a cookie `USE_FULL_SITE=1` then check and change the design package. In desktop version they will see a link "View mobile version" but when they click that link and I set `USE_FULL_SITE=0`, varnish return the same page.

This PR add ability to add custom cookie key to the varnish hash, I created a configuration field in _Admin > System > Configurations > Turpentine > Caching Options > Cookie-based Caching > Cookie Keys_

I think people who use cookie to check and display/hide popup will have the same issue

Please consider to merge.

Thanks a lot,
Phu