### PR TITLE
Small fix for notice when CM_REDISSESSION_LOCKING_ENABLED is already defined

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Observer/Varnish.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Observer/Varnish.php
@@ -65,7 +65,8 @@ class Nexcessnet_Turpentine_Model_Observer_Varnish extends Varien_Event_Observer
      */
     public function fixCmRedisSessionLocks($eventObject) {
         if (Mage::helper('core')->isModuleEnabled('Cm_RedisSession')) {
-            if ( ! empty($_COOKIE['frontend']) && 'crawler-session' == $_COOKIE['frontend']) {
+            if ( ! empty($_COOKIE['frontend']) && 'crawler-session' == $_COOKIE['frontend'] &&
+                    !defined('CM_REDISSESSION_LOCKING_ENABLED') ) {
                 define('CM_REDISSESSION_LOCKING_ENABLED', false);
             }
         }


### PR DESCRIPTION
Example of the notice fixed here:
`2016-12-15T11:01:56+00:00 ERR (3): Notice: Constant CM_REDISSESSION_LOCKING_ENABLED already defined  in /path/to/httpdocs/app/code/community/Nexcessnet/Turpentine/Model/Observer/Varnish.`
This problem appears when other extensions are also setting `CM_REDISSESSION_LOCKING_ENABLED`.
