### PR TITLE
use X-Requested-With header in hash so that xhr and standard requests…

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/misc/version-2.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-2.vcl
@@ -288,6 +288,14 @@ sub vcl_hash {
         set req.hash += regsub(req.http.Cookie, "^.*?customer_group=([^;]*);*.*$", "\1");
     }
 
+    # Some extension controllers serve different results for a single url depending on
+    # whether the request is xhr. prototype and jquery both set X-Requested-With
+    # headers on ajax requests, we can use them in the hash so that both variations
+    # are served seperately
+    if (req.http.X-Requested-With) {
+      set req.hash += req.http.X-Requested-With
+    }
+
     return (hash);
 }
 

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
@@ -290,7 +290,16 @@ sub vcl_hash {
             req.http.Cookie ~ "customer_group=") {
         hash_data(regsub(req.http.Cookie, "^.*?customer_group=([^;]*);*.*$", "\1"));
     }
-    
+
+    # Some extension controllers serve different results for a single url depending on
+    # whether the request is xhr. prototype and jquery both set X-Requested-With
+    # headers on ajax requests, we can use them in the hash so that both variations
+    # are served seperately
+    if (req.http.X-Requested-With) {
+      std.log("hash_data xhr request - X-Requested-With: " + req.http.X-Requested-With);
+      hash_data(req.http.X-Requested-With);
+    }
+
     return (hash);
 }
 

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
@@ -310,6 +310,16 @@ sub vcl_hash {
             req.http.Cookie ~ "customer_group=") {
         hash_data(regsub(req.http.Cookie, "^.*?customer_group=([^;]*);*.*$", "\1"));
     }
+
+    # Some extension controllers serve different results for a single url if the
+    # request is xhr. both prototype and jquery set X-Requested-With headers
+    # on ajax requests so we can add that to the hash so that both variations
+    # are served seperately
+    if (req.http.X-Requested-With) {
+      std.log("hash_data xhr request - X-Requested-With: " + req.http.X-Requested-With);
+      hash_data(req.http.X-Requested-With);
+    }
+    
     std.log("vcl_hash end return lookup");
     return (lookup);
 }


### PR DESCRIPTION
Some Magento extensions serve different results for a single URL depending on whether the request is XHR or a standard browser request. For example the XHR may return a JSON object whereas the standard request returns an HTML page. For obvious reasons this could cause issues if either result is cached and served for the other request. 

I ran into an example of this using a third party layered navigation extension. The filtered products were loaded in with ajax and injected into the page, the browser URL was then updated with the history API to reflect the new page that was loaded. If the user then refreshed the page they would be served a JSON object that was originally served by the ajax request.

This wouldn't be an issue if we were able to cache ajax requests separately. Prototype and jQuery both set X-Requested-With headers with requests made through their respective Ajax tools, if this header is set we can add it to the cache hash meaning that they will be cached differently. I have implemented this solution in my development environment and it has resolved my issue, I don't believe it will affect existing functionality so it could be worth adding it to the default VCL to avoid similar problems.

This pull requests contains fixes for varnish versions 2, 3 and 4 vcl. Unfortunately I only have a working version of v4 set up so I haven't been able to test the versions 2 and 3 vcl files.