### PR TITLE
Add configuration for mobile user-agent regex

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
@@ -785,18 +785,23 @@ EOS;
      * @return string
      */
     protected function _vcl_sub_normalize_user_agent() {
-        /**
-         * Mobile regex from
-         * @link http://magebase.com/magento-tutorials/magento-design-exceptions-explained/
-         */
-        $tpl = <<<EOS
-if (req.http.User-Agent ~ "iP(?:hone|ad|od)|BlackBerry|Palm|Googlebot-Mobile|Mobile|mobile|mobi|Windows Mobile|Safari Mobile|Android|Opera (?:Mini|Mobi)") {
-        set req.http.X-Normalized-User-Agent = "mobile";
-    } else {
-        set req.http.X-Normalized-User-Agent = "other";
-    }
 
+        $mobileRegexp = $this->_getMobileUserAgentRegex();
+        $tpl = <<<EOS
+set req.http.X-Normalized-User-Agent = "other";
 EOS;
+        if(!empty($mobileRegexp)){
+            $tplContent = '
+            if (req.http.User-Agent ~ "'.$mobileRegexp.'") {
+        set req.http.X-Normalized-User-Agent = "mobile";
+    }';
+
+            $tpl .= <<<"EOS"
+$tplContent
+EOS;
+
+        }
+
         return $tpl;
     }
 
@@ -857,6 +862,16 @@ EOS;
     }
 
     /**
+     * Get the regex for mobile user agent
+     *
+     * @return string
+     */
+    protected function _getMobileUserAgentRegex() {
+        return trim(Mage::getStoreConfig(
+            'turpentine_vcl/normalization/user_agent_mobile_regexp' ));
+    }
+
+    /**
      * Get the allowed IPs when in maintenance mode
      *
      * @return string
@@ -910,7 +925,7 @@ EOS;
         $baseUrl = Mage::getBaseUrl(Mage_Core_Model_Store::URL_TYPE_WEB);
         $baseUrl = str_replace(array('http://', 'https://'), '', $baseUrl);
         $baseUrl = rtrim($baseUrl, '/');
-        
+
         switch (Mage::getStoreConfig('turpentine_varnish/servers/version')) {
             case 4.0:
             case 4.1:
@@ -1085,7 +1100,7 @@ sub vcl_synth {
             // set the vcl_error from Magento database
             $vars['vcl_synth'] = $this->_vcl_sub_synth();
         }
-        
+
         if (Mage::getStoreConfig('turpentine_varnish/general/https_redirect_fix')) {
             $vars['https_redirect'] = $this->_vcl_sub_https_redirect_fix();
             if (Mage::getStoreConfig('turpentine_varnish/servers/version') == '4.0' || Mage::getStoreConfig('turpentine_varnish/servers/version') == '4.1') {

--- a/app/code/community/Nexcessnet/Turpentine/etc/config.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/config.xml
@@ -68,6 +68,7 @@
             <normalization>
                 <encoding>1</encoding>
                 <user_agent>0</user_agent>
+                <user_agent_mobile_regexp><![CDATA[iP(?:hone|ad|od)|BlackBerry|Palm|Googlebot-Mobile|Mobile|mobile|mobi|Windows Mobile|Safari Mobile|Android|Opera (?:Mini|Mobi)]]></user_agent_mobile_regexp>
                 <host>0</host>
             </normalization>
             <ttls>

--- a/app/code/community/Nexcessnet/Turpentine/etc/system.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/system.xml
@@ -449,6 +449,18 @@
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
                         </user_agent>
+                        <user_agent_mobile_regexp translate="label" module="turpentine">
+                            <label>Regexp for Mobile User-Agent</label>
+                            <comment><![CDATA[See for example http://magebase.com/magento-tutorials/magento-design-exceptions-explained/]]></comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>25</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                            <depends>
+                                <user_agent>1</user_agent>
+                            </depends>
+                        </user_agent_mobile_regexp>
                         <host translate="label" module="turpentine">
                             <label>Normalize Host</label>
                             <comment>Force requests to be for a specific domain name, will probably break most multi-store setups</comment>


### PR DESCRIPTION
Because I needed to change this regexp in a project and I had to override the Nexcessnet_Turpentine_Model_Varnish_Configurator_Abstract in order to achieve it.
