### PR TITLE
PHP7 Method Signature Inheritance Fix

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Version4.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Version4.php
@@ -144,7 +144,8 @@ EOS;
             $parts = explode(':', $backendNode, 2);
             $host = (empty($parts[0])) ? '127.0.0.1' : $parts[0];
             $port = (empty($parts[1])) ? '80' : $parts[1];
-            $backends .= $this->_vcl_director_backend($host, $port, $prefix.$number, $probeUrl, $backendOptions);
+            $descriptor = $prefix.$number;
+            $backends .= $this->_vcl_director_backend($host, $port, $probeUrl, $backendOptions, $descriptor);
 
             $number++;
         }
@@ -165,7 +166,7 @@ EOS;
      * @param array  $options    extra options for backend
      * @return string
      */
-    protected function _vcl_director_backend($host, $port, $descriptor, $probeUrl = '', $options = array()) {
+    protected function _vcl_director_backend($host, $port, $probeUrl = '', $options = array(), $descriptor = '') {
         $tpl = <<<EOS
         backend web{$descriptor} {
             .host = "{{host}}";


### PR DESCRIPTION
PHP7 throws the following warning

> Warning: Declaration of Nexcessnet_Turpentine_Model_Varnish_Configurator_Version4::_vcl_director_backend($host, $port, $descriptor, $probeUrl = '', $options = Array) should be compatible with Nexcessnet_Turpentine_Model_Varnish_Configurator_Abstract::_vcl_director_backend($host, $port, $probeUrl = '', $options = Array)

Because Configurator_Version4 is redefining the method signature of
_vcl_director_backend. It makes no practical difference because it's
only called from _vcl_directory, which is also redefined, but PHP7 will
stop throwing the warning if the parameter has a default value. I also
moved it to the end to make it clear which parameter was new.