### PR TITLE
Don't set X-Forwarded-For in vlc_recv for v4

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
@@ -111,16 +111,6 @@ sub vcl_recv {
 
     {{https_redirect}}
 
-    # this always needs to be done so it's up at the top
-    if (req.restarts == 0) {
-        if (req.http.X-Forwarded-For) {
-            set req.http.X-Forwarded-For =
-                req.http.X-Forwarded-For + ", " + client.ip;
-        } else {
-            set req.http.X-Forwarded-For = client.ip;
-        }
-    }
-
     # We only deal with GET and HEAD by default
     # we test this here instead of inside the url base regex section
     # so we can disable caching for the entire site if needed


### PR DESCRIPTION
According to https://varnish-cache.org/docs/5.0/whats-new/upgrading-4.0.html#x-forwarded-for-is-now-set-before-vcl-recv

> In many cases, people unintentionally removed X-Forwarded-For when
> implementing their own vcl_recv. Therefore it has been moved to before
> vcl_recv, so if you don't want an IP added to it, you should remove it
> in vcl_recv.

Leaving the fragment in vcl_recv results in the proxy ip being inserted
twice.