### PR TITLE
Add real_ip configuration option.

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
@@ -549,6 +549,18 @@ EOS;
     }
 
     /**
+     * Return client.ip or std.ip(X-Real-IP)
+     *
+     * @return string
+     */
+    protected function _getRealIp() {
+        if (Mage::getStoreConfig('turpentine_varnish/general/real_ip')) {
+            return 'std.ip(req.http.x-real-ip, "0.0.0.0")';
+        }
+        return 'client.ip';
+    }
+
+    /**
      * Get the regex formatted list of crawler user agents
      *
      * @return string
@@ -1057,6 +1069,7 @@ sub vcl_synth {
                 $this->_getVclTemplateFilename(self::VCL_CUSTOM_C_CODE_FILE) ),
             'esi_private_ttl'   => Mage::helper('turpentine/esi')
                 ->getDefaultEsiTtl(),
+            'real_ip' => $this->_getRealIp(),
         );
 
         if ((bool) Mage::getStoreConfig('turpentine_vcl/urls/bypass_cache_store_url')) {

--- a/app/code/community/Nexcessnet/Turpentine/etc/config.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/config.xml
@@ -30,6 +30,7 @@
                 <strip_vcl_whitespace>always</strip_vcl_whitespace>
                 <varnish_debug>0</varnish_debug>
                 <vcl_fix>1</vcl_fix>
+                <real_ip>0</real_ip>
                 <block_debug>0</block_debug>
                 <ajax_messages>1</ajax_messages>
                 <fix_product_toolbar>0</fix_product_toolbar>

--- a/app/code/community/Nexcessnet/Turpentine/etc/system.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/system.xml
@@ -82,6 +82,16 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </https_redirect_fix>
+                        <real_ip translate="label comment">
+                            <label>Use X-Real-IP Header</label>
+                            <comment>If there is a proxy in front of varnish(e.g. https) and it is not using proxy-protocol (varnish 4.1 only) to communicate with varnish, set this to Enable to replace client.ip with IP from X-Real-IP when comparing to ACLs.</comment>
+                            <frontend_type>select</frontend_type>
+                            <sort_order>26</sort_order>
+                            <source_model>adminhtml/system_config_source_enabledisable</source_model>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </real_ip>
                         <varnish_debug translate="label" module="turpentine">
                             <label>Enable Debug Info</label>
                             <comment>It is a major security vulnerability, to leave this enabled on production sites</comment>
@@ -153,6 +163,9 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <depends>
+                                <crawler_enable>1</crawler_enable>
+                            </depends>
                         </crawler_debug>
                         <crawler_batchsize translate="label" module="turpentine">
                             <label>Crawler Batch Size</label>

--- a/app/code/community/Nexcessnet/Turpentine/etc/system.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/system.xml
@@ -86,7 +86,7 @@
                             <label>Use X-Real-IP Header</label>
                             <comment>If there is a proxy in front of varnish(e.g. https) and it is not using proxy-protocol (varnish 4.1 only) to communicate with varnish, set this to Enable to replace client.ip with IP from X-Real-IP when comparing to ACLs.</comment>
                             <frontend_type>select</frontend_type>
-                            <sort_order>26</sort_order>
+                            <sort_order>29</sort_order>
                             <source_model>adminhtml/system_config_source_enabledisable</source_model>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-2.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-2.vcl
@@ -174,7 +174,7 @@ sub vcl_recv {
         }
         # no frontend cookie was sent to us
         if (req.http.Cookie !~ "frontend=") {
-            if (client.ip ~ crawler_acl ||
+            if ({{real_ip}} ~ crawler_acl ||
                     req.http.User-Agent ~ "^(?:{{crawler_user_agent_regex}})$") {
                 # it's a crawler, give it a fake cookie
                 set req.http.Cookie = "frontend=crawler-session";
@@ -399,7 +399,7 @@ sub vcl_deliver {
         set resp.http.Cache-Control = "no-cache";
     }
     set resp.http.X-Opt-Debug-Headers = "{{debug_headers}}";
-    if (resp.http.X-Opt-Debug-Headers == "true" || client.ip ~ debug_acl ) {
+    if (resp.http.X-Opt-Debug-Headers == "true" || {{real_ip}} ~ debug_acl ) {
         # debugging is on, give some extra info
         set resp.http.X-Varnish-Hits = obj.hits;
         set resp.http.X-Varnish-Esi-Method = req.http.X-Varnish-Esi-Method;

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
@@ -174,14 +174,14 @@ sub vcl_recv {
             # throw a forbidden error if debugging is off and a esi block is
             # requested by the user (does not apply to ajax blocks)
             if (req.http.X-Varnish-Esi-Method == "esi" && req.esi_level == 0 &&
-                    !({{debug_headers}} || client.ip ~ debug_acl)) {
+                    !({{debug_headers}} || {{real_ip}} ~ debug_acl)) {
                 error 403 "External ESI requests are not allowed";
             }
         }
         {{allowed_hosts}}
         # no frontend cookie was sent to us AND this is not an ESI or AJAX call
         if (req.http.Cookie !~ "frontend=" && !req.http.X-Varnish-Esi-Method) {
-            if (client.ip ~ crawler_acl ||
+            if ({{real_ip}} ~ crawler_acl ||
                     req.http.User-Agent ~ "^(?:{{crawler_user_agent_regex}})$") {
                 # it's a crawler, give it a fake cookie
                 set req.http.Cookie = "frontend=crawler-session";
@@ -418,7 +418,7 @@ sub vcl_deliver {
     if (req.http.X-Varnish-Esi-Method == "ajax" && req.http.X-Varnish-Esi-Access == "private") {
         set resp.http.Cache-Control = "no-cache";
     }
-    if ({{debug_headers}} || client.ip ~ debug_acl) {
+    if ({{debug_headers}} || {{real_ip}} ~ debug_acl) {
         # debugging is on, give some extra info
         set resp.http.X-Varnish-Hits = obj.hits;
         set resp.http.X-Varnish-Esi-Method = req.http.X-Varnish-Esi-Method;

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
@@ -171,14 +171,14 @@ sub vcl_recv {
             # throw a forbidden error if debugging is off and a esi block is
             # requested by the user (does not apply to ajax blocks)
             if (req.http.X-Varnish-Esi-Method == "esi" && req.esi_level == 0 &&
-                    !({{debug_headers}} || client.ip ~ debug_acl)) {
+                    !({{debug_headers}} || {{real_ip}} ~ debug_acl)) {
                 return (synth(403, "External ESI requests are not allowed"));
             }
         }
         {{allowed_hosts}}
         # no frontend cookie was sent to us AND this is not an ESI or AJAX call
         if (req.http.Cookie !~ "frontend=" && !req.http.X-Varnish-Esi-Method) {
-            if (client.ip ~ crawler_acl ||
+            if ({{real_ip}} ~ crawler_acl ||
                     req.http.User-Agent ~ "^(?:{{crawler_user_agent_regex}})$") {
                 # it's a crawler, give it a fake cookie
                 set req.http.Cookie = "frontend=crawler-session";
@@ -440,7 +440,7 @@ sub vcl_deliver {
     if (req.http.X-Varnish-Esi-Method == "ajax" && req.http.X-Varnish-Esi-Access == "private") {
         set resp.http.Cache-Control = "no-cache";
     }
-    if ({{debug_headers}} || client.ip ~ debug_acl) {
+    if ({{debug_headers}} || {{real_ip}} ~ debug_acl) {
         # debugging is on, give some extra info
         set resp.http.X-Varnish-Hits = obj.hits;
         set resp.http.X-Varnish-Esi-Method = req.http.X-Varnish-Esi-Method;


### PR DESCRIPTION
If:
* There is a proxy in front of varnish (e.g. https)
* The proxy is not connecting to varnish via the proxy protocol
(available in varnish >= 4.1)

client.ip will be the ip address of the proxy, which is probably not
correct, see: https://info.varnish-software.com/blog/failure-to-purge-a-story-about-client.ip-and-proxies

If the real_ip configuration option is enabled, then the vcl generated
will compare ACLs to std.ip(req.http.x-real-ip, "0.0.0.0").

X-Real-IP should be set by the upstream proxy.