### PR TITLE
Fix load balancing POST requests

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Version4.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Version4.php
@@ -80,6 +80,7 @@ class Nexcessnet_Turpentine_Model_Varnish_Configurator_Version4
         $tpl = <<<EOS
     new vdir       = directors.round_robin();
     new vdir_admin = directors.round_robin();
+
 EOS;
 
         if ('yes_admin' == Mage::getStoreConfig('turpentine_vcl/backend/load_balancing')) {
@@ -96,12 +97,14 @@ EOS;
         for ($i = 0, $iMax = count($backendNodes); $i < $iMax; $i++) {
             $tpl .= <<<EOS
     vdir.add_backend(web{$i});
+
 EOS;
         }
 
         for ($i = 0, $iMax = count($adminBackendNodes); $i < $iMax; $i++) {
             $tpl .= <<<EOS
     vdir_admin.add_backend(webadmin{$i});
+
 EOS;
         }
 

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
@@ -103,7 +103,7 @@ sub generate_session_expires {
 ## Varnish Subroutines
 
 sub vcl_init {
-    {{directors}}
+{{directors}}
 }
 
 sub vcl_recv {
@@ -113,7 +113,7 @@ sub vcl_recv {
         {{set_backend_hint}}
     }
 
-       {{maintenance_allowed_ips}}
+    {{maintenance_allowed_ips}}
 
     {{https_redirect}}
 

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
@@ -107,7 +107,13 @@ sub vcl_init {
 }
 
 sub vcl_recv {
-	{{maintenance_allowed_ips}}
+    if (req.url ~ "{{url_base_regex}}{{admin_frontname}}") {
+        set req.backend_hint = {{admin_backend_hint}};
+    } else {
+        {{set_backend_hint}}
+    }
+
+       {{maintenance_allowed_ips}}
 
     {{https_redirect}}
 
@@ -148,10 +154,7 @@ sub vcl_recv {
         set req.http.X-Turpentine-Secret-Handshake = "{{secret_handshake}}";
         # use the special admin backend and pipe if it's for the admin section
         if (req.url ~ "{{url_base_regex}}{{admin_frontname}}") {
-            set req.backend_hint = {{admin_backend_hint}};
             return (pipe);
-        } else {
-            {{set_backend_hint}}
         }
         if (req.http.Cookie ~ "\bcurrency=") {
             set req.http.X-Varnish-Currency = regsub(


### PR DESCRIPTION
Varnish v4: Moved configuration of directors to top of `sub vcl_recv`
Reason: Also load-balance traffic which hits `return (pipe)` like POST requests, or traffic which is not part of Magento.
I made this change for Kega, @itnova