### PR TITLE
When using hitch, we need to set http.X-Forwarded-Proto to HTTPS to p…

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/etc/system.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/system.xml
@@ -72,6 +72,16 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </vcl_fix>
+                        <https_proto_fix translate="label comment">
+                            <label>Set X-Forwarded-Proto Header to HTTPS on port 443</label>
+                            <comment>When using Varnish on port 80 and hitch on port 443 for HTTPS, the fix will set X-Forwarded-Proto header to HTTPS to prevent a re-direct loop.</comment>
+                            <frontend_type>select</frontend_type>
+                            <sort_order>27</sort_order>
+                            <source_model>adminhtml/system_config_source_enabledisable</source_model>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </https_proto_fix>
                         <https_redirect_fix translate="label comment">
                             <label>Fix HTTPS redirect</label>
                             <comment>When using Varnish as front door listen on port 80 and Nginx/Apache listen on port 443 for HTTPS, the fix will keep the url parameters when redirect from HTTP to HTTPS.</comment>

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
@@ -109,6 +109,7 @@ sub vcl_init {
 sub vcl_recv {
 	{{maintenance_allowed_ips}}
 
+    {{https_proto_fix}}
     {{https_redirect}}
 
     # this always needs to be done so it's up at the top


### PR DESCRIPTION
…revent a re-direct loop

Hitch (the TLS proxy) will not set any headers even when listening on port 443. This causes an issue because Magento is expecting an off loader header to know that it is on a secure connection.

This PR will set X-Forwarded-Proto to https when the originating connection from Hitch is port 443, thus preventing a redirect loop in Magento. This has to be done in Varnish VCL, as Hitch does not modify headers.

https://hitch-tls.org/