### PR TITLE
When rendering an ESI, get last block found in the XML instead of the first

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Helper/Esi.php
+++ b/app/code/community/Nexcessnet/Turpentine/Helper/Esi.php
@@ -375,13 +375,13 @@ class Nexcessnet_Turpentine_Helper_Esi extends Mage_Core_Helper_Abstract {
      */
     public function getEsiLayoutBlockNode($layout, $blockName) {
         // first try very specific by checking for action setEsiOptions inside block
-        $blockNode = current($layout->getNode()->xpath(
+        $blockNode = end($layout->getNode()->xpath(
             sprintf('//block[@name=\'%s\'][action[@method=\'setEsiOptions\']]',
                 $blockName)
         ));
         // fallback: only match name
         if ( ! ($blockNode instanceof Mage_Core_Model_Layout_Element)) {
-            $blockNode = current($layout->getNode()->xpath(
+            $blockNode = end($layout->getNode()->xpath(
                 sprintf('//block[@name=\'%s\']', $blockName)
             ));
         }


### PR DESCRIPTION
If I have a block declared 2 times (ie: "catalog.product.related", re-declared in the EE targetrule.xml) I should get the last one, as Magento would do.