### PR TITLE
Fix for custom cookie domain

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
@@ -1006,7 +1006,42 @@ sub vcl_synth {
         return $tpl;
     }
 
-
+    /**
+     * Get VCL for fixing cookie domain
+     *
+     * @return string
+     */
+    protected function _vcl_sub_set_cookie_domain()
+    {
+        $tpl = '';
+        /** @var Mage_Core_Model_Store $store */
+        $domain2cookie = array();
+        foreach (Mage::app()->getStores() as $store) {
+            $cookieDomain = $store->getConfig(Mage_Core_Model_Cookie::XML_PATH_COOKIE_DOMAIN);
+            if (!$cookieDomain) {
+                continue;
+            }
+            $urlDomainUnsecure = parse_url($store->getBaseUrl(Mage_Core_Model_Store::URL_TYPE_LINK, false), PHP_URL_HOST);
+            $urlDomainSecure = parse_url($store->getBaseUrl(Mage_Core_Model_Store::URL_TYPE_LINK, true), PHP_URL_HOST);
+            if ($urlDomainUnsecure && $urlDomainUnsecure != $cookieDomain) {
+                $domain2cookie[$urlDomainUnsecure] = $cookieDomain;
+            }
+            if ($urlDomainSecure && $urlDomainSecure != $cookieDomain) {
+                $domain2cookie[$urlDomainSecure] = $cookieDomain;
+            }
+        }
+        $count = 0;
+        foreach ($domain2cookie as $domain => $cookieDomain) {
+            $if = ($count == 0) ? '                    if' : ' elsif';
+            $tpl .= <<<EOS
+$if (resp.http.X-Varnish-CookieDomain == "$domain") {
+                        set resp.http.X-Varnish-CookieDomain = "$cookieDomain";
+                    }
+EOS;
+            $count++;
+        }
+        return $tpl;
+    }
 
     /**
      * Build the list of template variables to apply to the VCL template
@@ -1057,6 +1092,7 @@ sub vcl_synth {
                 $this->_getVclTemplateFilename(self::VCL_CUSTOM_C_CODE_FILE) ),
             'esi_private_ttl'   => Mage::helper('turpentine/esi')
                 ->getDefaultEsiTtl(),
+            'set_cookie_domain' => $this->_vcl_sub_set_cookie_domain(),
         );
 
         if ((bool) Mage::getStoreConfig('turpentine_vcl/urls/bypass_cache_store_url')) {

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-2.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-2.vcl
@@ -389,8 +389,10 @@ sub vcl_deliver {
         set resp.http.Set-Cookie = req.http.X-Varnish-Faked-Session "; expires="
             resp.http.X-Varnish-Cookie-Expires "; path=/";
         if (req.http.Host) {
+            set resp.http.X-Varnish-CookieDomain = regsub(req.http.Host, ":\d+$", "");
+{{set_cookie_domain}}
             set resp.http.Set-Cookie = resp.http.Set-Cookie
-                "; domain=" regsub(req.http.Host, ":\d+$", "");
+                "; domain=" resp.http.X-Varnish-CookieDomain;
         }
         set resp.http.Set-Cookie = resp.http.Set-Cookie "; HttpOnly";
         remove resp.http.X-Varnish-Cookie-Expires;
@@ -419,6 +421,7 @@ sub vcl_deliver {
         remove resp.http.X-Varnish-Session;
         remove resp.http.X-Varnish-Host;
         remove resp.http.X-Varnish-URL;
+        remove resp.http.X-Varnish-CookieDomain;
         # this header indicates the session that originally generated a cached
         # page. it *must* not be sent to a client in production with lax
         # session validation or that session can be hijacked

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-3.vcl
@@ -407,8 +407,10 @@ sub vcl_deliver {
                     set resp.http.Set-Cookie = resp.http.Set-Cookie +
                     "; domain={{normalize_cookie_target}}";
                 } else {
+                    set resp.http.X-Varnish-CookieDomain = regsub(req.http.Host, ":\d+$", "");
+{{set_cookie_domain}}
                     set resp.http.Set-Cookie = resp.http.Set-Cookie +
-                    "; domain=" + regsub(req.http.Host, ":\d+$", "");
+                    "; domain=" + resp.http.X-Varnish-CookieDomain;
                 }
             }
         }
@@ -438,6 +440,7 @@ sub vcl_deliver {
         unset resp.http.X-Varnish-Session;
         unset resp.http.X-Varnish-Host;
         unset resp.http.X-Varnish-URL;
+        unset resp.http.X-Varnish-CookieDomain;
         # this header indicates the session that originally generated a cached
         # page. it *must* not be sent to a client in production with lax
         # session validation or that session can be hijacked

--- a/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
+++ b/app/code/community/Nexcessnet/Turpentine/misc/version-4.vcl
@@ -429,8 +429,10 @@ sub vcl_deliver {
                     set resp.http.Set-Cookie = resp.http.Set-Cookie +
                     "; domain={{normalize_cookie_target}}";
                 } else {
+                    set resp.http.X-Varnish-CookieDomain = regsub(req.http.Host, ":\d+$", "");
+{{set_cookie_domain}}
                     set resp.http.Set-Cookie = resp.http.Set-Cookie +
-                    "; domain=" + regsub(req.http.Host, ":\d+$", "");
+                    "; domain=" + resp.http.X-Varnish-CookieDomain;
                 }
             }
         }
@@ -460,6 +462,7 @@ sub vcl_deliver {
         unset resp.http.X-Varnish-Session;
         unset resp.http.X-Varnish-Host;
         unset resp.http.X-Varnish-URL;
+        unset resp.http.X-Varnish-CookieDomain;
         # this header indicates the session that originally generated a cached
         # page. it *must* not be sent to a client in production with lax
         # session validation or that session can be hijacked


### PR DESCRIPTION
The cookie is set by Magento when "Use VLC fix" is set to "Disabled" via config.
When a custom cookie domain is configured in Magento, this was not used in the VCL.
Then the cookie domain was wrong, which resulted in checkout not working.
This commit fixes this problem.

I made this change for Kega, @itnova