### PR TITLE
Dispatch event in _getTemplateVars to allow other extensions to add custom vcl template variables

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Version2.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Version2.php
@@ -23,6 +23,8 @@ class Nexcessnet_Turpentine_Model_Varnish_Configurator_Version2
     extends Nexcessnet_Turpentine_Model_Varnish_Configurator_Abstract {
 
     const VCL_TEMPLATE_FILE = 'version-2.vcl';
+    const VCL_VERSION = '2';
+
 
     /**
      * Generate the Varnish 2.1-compatible VCL
@@ -55,6 +57,13 @@ class Nexcessnet_Turpentine_Model_Varnish_Configurator_Version2
         $vars['esi_public_ttl'] = $this->_getDefaultTtl();
         $vars['advanced_session_validation'] =
             $this->_getAdvancedSessionValidation();
+
+        //dispatch event to allow other extensions to add custom vcl template variables
+        Mage::dispatchEvent('turpentine_get_templatevars_after', array(
+            'vars' => &$vars,
+            'vcl_version'=> self::VCL_VERSION
+        ));
+
         return $vars;
     }
 }

--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Version3.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Version3.php
@@ -23,6 +23,8 @@ class Nexcessnet_Turpentine_Model_Varnish_Configurator_Version3
     extends Nexcessnet_Turpentine_Model_Varnish_Configurator_Abstract {
 
     const VCL_TEMPLATE_FILE = 'version-3.vcl';
+    const VCL_VERSION = '3';
+
 
     /**
      * Generate the Varnish 3.0-compatible VCL
@@ -60,6 +62,13 @@ class Nexcessnet_Turpentine_Model_Varnish_Configurator_Version3
         $vars = parent::_getTemplateVars();
         $vars['advanced_session_validation'] =
             $this->_getAdvancedSessionValidation();
+
+        //dispatch event to allow other extensions to add custom vcl template variables
+        Mage::dispatchEvent('turpentine_get_templatevars_after', array(
+            'vars' => &$vars,
+            'vcl_version'=> self::VCL_VERSION
+        ));
+
         return $vars;
     }
 }

--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Version4.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Version4.php
@@ -23,6 +23,8 @@ class Nexcessnet_Turpentine_Model_Varnish_Configurator_Version4
     extends Nexcessnet_Turpentine_Model_Varnish_Configurator_Abstract {
 
     const VCL_TEMPLATE_FILE = 'version-4.vcl';
+    const VCL_VERSION = '4';
+
 
     /**
      * Generate the Varnish 4.0-compatible VCL
@@ -71,6 +73,12 @@ class Nexcessnet_Turpentine_Model_Varnish_Configurator_Version4
             $vars['admin_backend_hint'] = 'admin';
             $vars['set_backend_hint']   = '';
         }
+
+        //dispatch event to allow other extensions to add custom vcl template variables
+        Mage::dispatchEvent('turpentine_get_templatevars_after', array(
+            'vars' => &$vars,
+            'vcl_version'=> self::VCL_VERSION
+        ));
 
         return $vars;
     }


### PR DESCRIPTION
I want to add site specific customisations to my vcl that would be based on Magento config but don't make sense to be added to turpentine for everyone.

Adding this event allows me to create a custom extension which will add additional template vars which I can then use in my vcl. 
