### PR TITLE
use 503 response for maintenance page rather than 404

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
@@ -971,7 +971,7 @@ EOS;
                 $tpl = <<<EOS
 sub vcl_synth {
     if (resp.status == 999) {
-        set resp.status = 404;
+        set resp.status = 503;
         set resp.http.Content-Type = "text/html; charset=utf-8";
         synthetic({"{{vcl_synth_content}}"});
         return (deliver);


### PR DESCRIPTION
Is there a reason that the maintenance page has a 404 response and not a 503? All good if there is, I just thought using a 503 made more sense.