### PR TITLE
added ESI options for contact form, #116, #486

### DIFF
--- a/app/design/frontend/base/default/layout/turpentine_esi.xml
+++ b/app/design/frontend/base/default/layout/turpentine_esi.xml
@@ -455,6 +455,18 @@
         <turpentine_cache_flag value="0"/>
     </customer_account_confirmation>
 
+    <contacts_index_index>
+        <reference name="contactForm">
+            <action method="setEsiOptions">
+                <params>
+                    <method>esi</method>
+                    <access>private</access>
+                    <ttl>0</ttl>
+                </params>
+            </action>
+        </reference>
+    </contacts_index_index>
+
 <!--
     <customer_account_edit>
         <turpentine_cache_flag value="0"/>

--- a/app/design/frontend/base/default/layout/turpentine_esi.xml
+++ b/app/design/frontend/base/default/layout/turpentine_esi.xml
@@ -456,15 +456,8 @@
     </customer_account_confirmation>
 
     <contacts_index_index>
-        <reference name="contactForm">
-            <action method="setEsiOptions">
-                <params>
-                    <method>esi</method>
-                    <access>private</access>
-                    <ttl>0</ttl>
-                </params>
-            </action>
-        </reference>
+        <!-- wholepunching the contactForm block is not enough since the form action is wrong in this case -->
+        <turpentine_cache_flag value="0"/>
     </contacts_index_index>
 
 <!--


### PR DESCRIPTION
This ensures that no user data is stored in Varnish (the contact form is pre-filled with user data for logged in users).