### PR TITLE
fixed MageWorx_XSitemap compatibility

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Helper/Cron.php
+++ b/app/code/community/Nexcessnet/Turpentine/Helper/Cron.php
@@ -192,7 +192,7 @@ class Nexcessnet_Turpentine_Helper_Cron extends Mage_Core_Helper_Abstract {
                 }
             }
             $sitemap = (Mage::getConfig()->getNode('modules/MageWorx_XSitemap') !== FALSE) ?
-                                                           'xsitemap/cms_page' : 'sitemap/cms_page';
+                                                           'mageworx_xsitemap/cms_page' : 'sitemap/cms_page';
             foreach (Mage::getResourceModel($sitemap)
                         ->getCollection($storeId) as $item) {
                 $urls[] = $baseUrl.$item->getUrl();


### PR DESCRIPTION
MageWorx_XSitemap used to use `xsitemap` for their models, but they now use `mageworx_xsitemap`.