### PR TITLE
fixed admin_messages in frontend, fixes #940

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Block/Core/Messages.php
+++ b/app/code/community/Nexcessnet/Turpentine/Block/Core/Messages.php
@@ -316,15 +316,7 @@ class Nexcessnet_Turpentine_Block_Core_Messages extends Mage_Core_Block_Messages
      */
     protected function _real_toHtml() {
         if ( ! $this->_directCall) {
-            switch ($this->getNameInLayout()) {
-                case 'global_messages':
-                    $this->_directCall = 'getHtml';
-                    break;
-                case 'messages':
-                default:
-                    $this->_directCall = 'getGroupedHtml';
-                    break;
-            }
+            $this->_directCall = 'getGroupedHtml';
         }
         switch ($this->_directCall) {
             case 'getHtml':


### PR DESCRIPTION
Following up on #940 here. The distinction between `getHtml` for the `global_messages` and `getGroupedHtml` for the `messages` is quite old:

https://github.com/nexcess/magento-turpentine/blame/44d7b7627b2656ae87aa29b5a6a52e4e774fd33d/app/code/community/Nexcessnet/Turpentine/Block/Core/Messages.php#L319-L327

It should be absolutely okay to always use `getGroupedHtml`:

- for the `messages`, `getGroupedHtml` is already used, so nothing changes for this block
- the `global_messages` block is always called via `<?php echo $this->getChildHtml('global_messages') ?>`
- `Mage_Core_Block_Abstract::getChildHtml` calls `Mage_Core_Block_Abstract::_getChildHtml`
- `Mage_Core_Block_Abstract::_getChildHtml` calls `Mage_Core_Block_Abstract::toHtml`
- `Mage_Core_Block_Abstract::toHtml` calls `Mage_Core_Block_Messages::_toHtml`
- `Mage_Core_Block_Messages::_toHtml` **always** uses `Mage_Core_Block_Messages::getGroupedHtml` - hence, we can use it as well