### PR TITLE
Fix for notice 'Only variables should be passed by reference' in PHP 7.

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Helper/Esi.php
+++ b/app/code/community/Nexcessnet/Turpentine/Helper/Esi.php
@@ -379,15 +379,17 @@ class Nexcessnet_Turpentine_Helper_Esi extends Mage_Core_Helper_Abstract {
      */
     public function getEsiLayoutBlockNode($layout, $blockName) {
         // first try very specific by checking for action setEsiOptions inside block
-        $blockNode = end($layout->getNode()->xpath(
+        $blockNodes = $layout->getNode()->xpath(
             sprintf('//block[@name=\'%s\'][action[@method=\'setEsiOptions\']]',
                 $blockName)
-        ));
+        );
+        $blockNode = end($blockNodes);
         // fallback: only match name
         if ( ! ($blockNode instanceof Mage_Core_Model_Layout_Element)) {
-            $blockNode = end($layout->getNode()->xpath(
+            $blockNodes = $layout->getNode()->xpath(
                 sprintf('//block[@name=\'%s\']', $blockName)
-            ));
+            );
+            $blockNode = end($blockNodes);
         }
         return $blockNode;
     }


### PR DESCRIPTION
We like to keep notices to keep our code clean. These lines gave a notice in PHP 7.x:
```
2018-09-13T08:27:47+00:00 ERR (3): Notice: Only variables should be passed by reference  in /path/to/httpdocs/.modman/magento-turpentine/app/code/community/Nexcessnet/Turpentine/Helper/Esi.php on line 384
2018-09-13T08:27:47+00:00 ERR (3): Notice: Only variables should be passed by reference  in /path/to/httpdocs/.modman/magento-turpentine/app/code/community/Nexcessnet/Turpentine/Helper/Esi.php on line 389
```