### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Helper/Cron.php
+++ b/app/code/community/Nexcessnet/Turpentine/Helper/Cron.php
@@ -191,7 +191,7 @@ class Nexcessnet_Turpentine_Helper_Cron extends Mage_Core_Helper_Abstract {
                     $urls[] = $prod->getProductUrl();
                 }
             }
-            $sitemap = (Mage::getConfig()->getNode('modules/MageWorx_XSitemap') !== FALSE) ?
+            $sitemap = (Mage::getConfig()->getNode('modules/MageWorx_XSitemap') !== false) ?
                                                            'mageworx_xsitemap/cms_page' : 'sitemap/cms_page';
             foreach (Mage::getResourceModel($sitemap)
                         ->getCollection($storeId) as $item) {


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!