### PR TITLE
Fix wrong skin, template, locale in ESI blocks

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Observer/Esi.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Observer/Esi.php
@@ -344,7 +344,12 @@ class Nexcessnet_Turpentine_Model_Observer_Esi extends Varien_Event_Observer {
         $esiData = new Varien_Object();
         $esiData->setStoreId(Mage::app()->getStore()->getId());
         $esiData->setDesignPackage(Mage::getDesign()->getPackageName());
-        $esiData->setDesignTheme(Mage::getDesign()->getTheme('layout'));
+        $esiData->setDesignTheme(array(
+            'layout' => Mage::getDesign()->getTheme('layout'),
+            'template' => Mage::getDesign()->getTheme('template'),
+            'skin' => Mage::getDesign()->getTheme('skin'),
+            'locale' => Mage::getDesign()->getTheme('locale')
+        ));
         $esiData->setNameInLayout($blockObject->getNameInLayout());
         $esiData->setBlockType(get_class($blockObject));
         $esiData->setLayoutHandles($this->_getBlockLayoutHandles($blockObject));

--- a/app/code/community/Nexcessnet/Turpentine/controllers/EsiController.php
+++ b/app/code/community/Nexcessnet/Turpentine/controllers/EsiController.php
@@ -183,9 +183,17 @@ class Nexcessnet_Turpentine_EsiController extends Mage_Core_Controller_Front_Act
             }
         }
         $layout = Mage::getSingleton('core/layout');
-        Mage::getSingleton('core/design_package')
-                ->setPackageName($esiData->getDesignPackage())
-                ->setTheme($esiData->getDesignTheme());
+        $package = Mage::getSingleton('core/design_package')
+                ->setPackageName($esiData->getDesignPackage());
+        $theme = $esiData->getDesignTheme();
+        if (is_array($theme)) {
+            foreach ($theme as $type => $name) {
+                $package->setTheme($type, $name);
+            }
+        } else {
+            // for backwards compatibility during upgrades
+            $package->setTheme($theme);
+        }
 
         // This is, (roughly), the start of Action->loadLayout
         // - Mimicking Action->addActionLayoutHandles (Though we are using the esi data to set)


### PR DESCRIPTION
This fixes a bug were the wrong skin, template or locale is used when rendering ESI blocks and either of those values differs from the layout name.

One problem this fixes is wrong skin URLs, if the skin name differs from the layout name, which was previously fixed in #972, but later reverted in #1164.

The new fix passes the current layout, skin, template and locale as part of  the ESI data, instead of only the layout.

See #1164 for the discussion and #971 for the original bug report regarding wrong skin URLs.