### PR TITLE
Adminhtml cachecontroller not in use (XML missing)

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/controllers/Adminhtml/CacheController.php
+++ b/app/code/community/Nexcessnet/Turpentine/controllers/Adminhtml/CacheController.php
@@ -8,6 +8,27 @@ require_once Mage::getModuleDir('controllers', 'Mage_Adminhtml').DS.'CacheContro
 
 class Nexcessnet_Turpentine_Adminhtml_CacheController extends Mage_Adminhtml_CacheController
 {
+    public function indexAction()
+    {
+        $allTypes = Mage::app()->useCache();
+
+        $turpentineEnabled = ($allTypes['turpentine_pages'] == 1) || ($allTypes['turpentine_esi_blocks'] == 1);
+        $fullPageEnabled = (array_key_exists('full_page', $allTypes)) && ($allTypes['full_page'] == 1);
+
+        if ($fullPageEnabled && $turpentineEnabled) {
+            $allTypes['full_page'] = 0;
+            Mage::app()->saveUseCache($allTypes);
+
+            Mage::getSingleton('core/session')->addWarning(
+                Mage::helper('adminhtml')->__('Both Varnish and Full Page caches were enabled. Full Page cache has now been disabled.')
+            );
+
+            $this->_redirect('*/*');
+            return;
+        }
+
+        parent::indexAction();
+    }
 
     /**
      * Mass action for cache enabeling

--- a/app/code/community/Nexcessnet/Turpentine/etc/config.xml
+++ b/app/code/community/Nexcessnet/Turpentine/etc/config.xml
@@ -497,6 +497,7 @@
                 <args>
                     <modules>
                         <turpentine after="Mage_Adminhtml">Nexcessnet_Turpentine</turpentine>
+                        <turpentine_admin before="Mage_Adminhtml">Nexcessnet_Turpentine_Adminhtml</turpentine_admin>
                     </modules>
                 </args>
             </adminhtml>


### PR DESCRIPTION
The XML required for the core cache-controller override was introduced in #817, but this conflicted with the existing Turpentine controllers (duplicate XML node name). This conflict was identified in #821 and resolved in #823 by removing this line. Without this line, the overridden controller is not used (and therefore the protection it adds is not being applied).

This change reintroduces the required configuration in a non-conflicting way.

Because of this omission, it is possible for a site to be in a broken state (by mass enabling both turpentine & full_page caches at the same time). The second commit automatically resolves this issue when an administrator browses to the 'cache management' page. (Note that it's still possible to put a site into a problem state via command line, however with this second commit this too will be resolved automatically.)

I can split this into two separate pull requests if you'd prefer.